### PR TITLE
Add pre-commit GitHub Action

### DIFF
--- a/.github/workflows/precommit.yml
+++ b/.github/workflows/precommit.yml
@@ -1,0 +1,33 @@
+name: Pre-commit
+on:
+  push:
+    branches:
+      - '**'
+    tags-ignore:
+      - 'v*'
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  precommit:
+    runs-on: ubuntu-latest
+    container:
+      image: quay.io/opendatahub/pre-commit-go-toolchain:v0.2  # https://github.com/opendatahub-io/data-science-pipelines-operator/blob/main/.github
+      env:
+        XDG_CACHE_HOME: /cache
+        GOCACHE: /cache/go-build
+        GOMODCACHE: /cache/go-mod
+        PRE_COMMIT_HOME: /cache/pre-commit
+      volumes:
+        - /cache
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Activate cache
+        uses: actions/cache@v2
+        with:
+          path: /cache
+          key: ${{ runner.os }}-cache-${{ hashFiles('**/go.sum', '.pre-commit-config.yaml') }}
+
+      - name: Run pre-commit checks
+        run: pre-commit run --all-files


### PR DESCRIPTION
We are just re-using an image built by the Open Data Hub organization in this GitHub Action. As the functional goals are the same, it didn't make sense for us to start building a new image ourselves.