### PR TITLE
Don't add default values to config map if not specified.

### DIFF
--- a/api/v1alpha1/mcad_types.go
+++ b/api/v1alpha1/mcad_types.go
@@ -39,18 +39,14 @@ type MCADSpec struct {
 	PreemptionEnabled bool `json:"preemptionEnabled,omitempty"`
 
 	// AgentConfigs TODO: Add details
-	// +kubebuilder:default=null
 	AgentConfigs string `json:"agentConfigs,omitempty"`
 
 	// QuotaRestURL TODO: Add details
-	// +kubebuilder:default=null
 	QuotaRestURL string `json:"quotaRestURL,omitempty"`
 
 	// PodCreationTimeout TODO: Add details and confirm values
-	// +kubebuilder:default=300
+	// +kubebuilder:default=-1
 	PodCreationTimeout int `json:"podCreationTimeout,omitempty"`
-	//podCreationTimeout: //int (default blank)
-
 }
 
 // MCADStatus defines the observed state of MCAD

--- a/config/crd/bases/codeflare.codeflare.dev_mcads.yaml
+++ b/config/crd/bases/codeflare.codeflare.dev_mcads.yaml
@@ -36,7 +36,6 @@ spec:
             description: MCADSpec defines the desired state of MCAD
             properties:
               agentConfigs:
-                default: "null"
                 description: 'AgentConfigs TODO: Add details'
                 type: string
               dispatcherMode:
@@ -55,7 +54,7 @@ spec:
                   to multiple clusters.
                 type: boolean
               podCreationTimeout:
-                default: 300
+                default: -1
                 description: 'PodCreationTimeout TODO: Add details and confirm values'
                 type: integer
               preemptionEnabled:
@@ -64,7 +63,6 @@ spec:
                   preempted for others
                 type: boolean
               quotaRestURL:
-                default: "null"
                 description: 'QuotaRestURL TODO: Add details'
                 type: string
             type: object

--- a/config/internal/mcad/configmap.yaml.tmpl
+++ b/config/internal/mcad/configmap.yaml.tmpl
@@ -1,10 +1,10 @@
 apiVersion: v1
 data:
   DISPATCHER_MODE: "{{.DispatcherMode}}"
-  DISPATCHER_AGENT_CONFIGS: "{{.AgentConfigs}}"
   PREEMPTION: "{{.PreemptionEnabled}}"
-  QUOTA_REST_URL: "{{.QuotaRestURL}}"
-  DISPATCH_RESOURCE_RESERVATION_TIMEOUT: "{{.PodCreationTimeout}}"
+  {{if ne .AgentConfigs ""}}DISPATCHER_AGENT_CONFIGS: "{{.AgentConfigs}}"{{end}}
+  {{if ne .QuotaRestURL ""}}QUOTA_REST_URL: "{{.QuotaRestURL}}"{{end}}
+  {{if ne .PodCreationTimeout -1}}DISPATCH_RESOURCE_RESERVATION_TIMEOUT: "{{.PodCreationTimeout}}"{{end}}
 kind: ConfigMap
 metadata:
   name: mcad-{{.Name}}-config

--- a/controllers/mcad_controller.go
+++ b/controllers/mcad_controller.go
@@ -19,6 +19,7 @@ package controllers
 import (
 	"context"
 	"fmt"
+
 	"github.com/go-logr/logr"
 	mf "github.com/manifestival/manifestival"
 	"github.com/project-codeflare/codeflare-operator/controllers/config"
@@ -44,7 +45,6 @@ type MCADReconciler struct {
 }
 
 func (r *MCADReconciler) Apply(owner mf.Owner, params *MCADParams, template string, fns ...mf.Transformer) error {
-
 	tmplManifest, err := config.Manifest(r.Client, r.TemplatesPath+template, params, template, r.Log)
 	if err != nil {
 		return fmt.Errorf("error loading template yaml: %w", err)
@@ -81,6 +81,7 @@ func (r *MCADReconciler) ApplyWithoutOwner(params *MCADParams, template string, 
 	if err = tmplManifest.Apply(); err != nil {
 		return err
 	}
+
 	return nil
 }
 

--- a/controllers/mcad_controller_test.go
+++ b/controllers/mcad_controller_test.go
@@ -2,6 +2,7 @@ package controllers
 
 import (
 	"context"
+
 	mfc "github.com/manifestival/controller-runtime-client"
 	mf "github.com/manifestival/manifestival"
 	. "github.com/onsi/ginkgo/v2"
@@ -14,6 +15,13 @@ const (
 	mcadConfigMap1      = "./testdata/mcad_test_results/case_1/configmap.yaml"
 	mcadService1        = "./testdata/mcad_test_results/case_1/service.yaml"
 	mcadServiceAccount1 = "./testdata/mcad_test_results/case_1/serviceaccount.yaml"
+)
+
+const (
+	mcadCRCase2         = "./testdata/mcad_test_cases/case_2.yaml"
+	mcadConfigMap2      = "./testdata/mcad_test_results/case_2/configmap.yaml"
+	mcadService2        = "./testdata/mcad_test_results/case_2/service.yaml"
+	mcadServiceAccount2 = "./testdata/mcad_test_results/case_2/serviceaccount.yaml"
 )
 
 func deployMCAD(ctx context.Context, path string, opts mf.Option) {
@@ -38,4 +46,13 @@ var _ = Describe("The MCAD Controller", func() {
 		})
 	})
 
+	Context("In a namespace, when a populated MCAD Custom Resource is deployed", func() {
+
+		It("It should create a configmap", func() {
+			deployMCAD(ctx, mcadCRCase2, opts)
+			compareConfigMaps(mcadConfigMap2, opts)
+			compareServiceAccounts(mcadServiceAccount2, opts)
+			compareServices(mcadService2, opts)
+		})
+	})
 })

--- a/controllers/testdata/mcad_test_cases/case_2.yaml
+++ b/controllers/testdata/mcad_test_cases/case_2.yaml
@@ -1,0 +1,8 @@
+apiVersion: codeflare.codeflare.dev/v1alpha1
+kind: MCAD
+metadata:
+  name: populated-custom-resource
+spec:
+  podCreationTimeout: 300
+  quotaRestURL: 'bar.com'
+  agentConfigs: 'foo'

--- a/controllers/testdata/mcad_test_results/case_1/configmap.yaml
+++ b/controllers/testdata/mcad_test_results/case_1/configmap.yaml
@@ -7,8 +7,5 @@ metadata:
     app: mcad-blank-custom-resource
     component: multi-cluster-app-dispatcher
 data:
-  DISPATCHER_AGENT_CONFIGS: 'null'
   DISPATCHER_MODE: 'false'
-  DISPATCH_RESOURCE_RESERVATION_TIMEOUT: '300'
   PREEMPTION: 'false'
-  QUOTA_REST_URL: 'null'

--- a/controllers/testdata/mcad_test_results/case_2/configmap.yaml
+++ b/controllers/testdata/mcad_test_results/case_2/configmap.yaml
@@ -1,0 +1,14 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: mcad-populated-custom-resource-config
+  namespace: default
+  labels:
+    app: mcad-populated-custom-resource
+    component: multi-cluster-app-dispatcher
+data:
+  DISPATCHER_MODE: 'false'
+  PREEMPTION: 'false'
+  DISPATCHER_AGENT_CONFIGS: 'foo'
+  DISPATCH_RESOURCE_RESERVATION_TIMEOUT: '300'
+  QUOTA_REST_URL: 'bar.com'

--- a/controllers/testdata/mcad_test_results/case_2/rolebinding.yaml
+++ b/controllers/testdata/mcad_test_results/case_2/rolebinding.yaml
@@ -1,0 +1,13 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: populated-custom-resource-custom-metrics-auth-reader
+  namespace: default
+subjects:
+  - kind: ServiceAccount
+    name: mcad-controller-populated-custom-resource
+    namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: extension-apiserver-authentication-reader

--- a/controllers/testdata/mcad_test_results/case_2/service.yaml
+++ b/controllers/testdata/mcad_test_results/case_2/service.yaml
@@ -1,0 +1,26 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: mcad-populated-custom-resource-metrics
+  namespace: default
+spec:
+  clusterIP: 172.31.181.101
+  ipFamilies:
+    - IPv4
+  ports:
+    - name: https
+      protocol: TCP
+      port: 443
+      targetPort: 6443
+    - name: http
+      protocol: TCP
+      port: 80
+      targetPort: 8080
+  internalTrafficPolicy: Cluster
+  clusterIPs:
+    - 172.31.181.101
+  type: ClusterIP
+  ipFamilyPolicy: SingleStack
+  sessionAffinity: None
+  selector:
+    app: mcad-populated-custom-resource

--- a/controllers/testdata/mcad_test_results/case_2/serviceaccount.yaml
+++ b/controllers/testdata/mcad_test_results/case_2/serviceaccount.yaml
@@ -1,0 +1,5 @@
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: mcad-controller-populated-custom-resource
+  namespace: default


### PR DESCRIPTION
This allows MCAD to determine what an undefined value should default to

closes #53