### PR TITLE
Use uniquely identifying labels selector for the operator deployment

### DIFF
--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -9,8 +9,9 @@ namespace: openshift-operators
 namePrefix: codeflare-operator-
 
 # Labels to add to all resources and selectors.
-# commonLabels:
-#  someName: someValue
+commonLabels:
+  app.kubernetes.io/name: codeflare-operator
+  app.kubernetes.io/part-of: codeflare
 
 bases:
 - ../crd

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -3,7 +3,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: controller-manager
+  name: manager
   namespace: system
 spec:
   template:

--- a/config/default/manager_config_patch.yaml
+++ b/config/default/manager_config_patch.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: controller-manager
+  name: manager
   namespace: system
 spec:
   template:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -8,21 +8,23 @@ metadata:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: controller-manager
+  name: manager
   namespace: system
   labels:
     control-plane: controller-manager
 spec:
   selector:
     matchLabels:
-      control-plane: controller-manager
+      app.kubernetes.io/name: codeflare-operator
+      app.kubernetes.io/part-of: codeflare
   replicas: 1
   template:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: manager
       labels:
-        control-plane: controller-manager
+        app.kubernetes.io/name: codeflare-operator
+        app.kubernetes.io/part-of: codeflare
     spec:
       securityContext:
         runAsNonRoot: true

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -1,8 +1,6 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  labels:
-    control-plane: controller-manager
   name: system
 ---
 apiVersion: apps/v1
@@ -10,8 +8,6 @@ kind: Deployment
 metadata:
   name: manager
   namespace: system
-  labels:
-    control-plane: controller-manager
 spec:
   selector:
     matchLabels:

--- a/config/prometheus/monitor.yaml
+++ b/config/prometheus/monitor.yaml
@@ -4,7 +4,7 @@ kind: ServiceMonitor
 metadata:
   labels:
     control-plane: controller-manager
-  name: controller-manager-metrics-monitor
+  name: manager-metrics
   namespace: system
 spec:
   endpoints:
@@ -16,4 +16,5 @@ spec:
         insecureSkipVerify: true
   selector:
     matchLabels:
-      control-plane: controller-manager
+      app.kubernetes.io/name: codeflare-operator
+      app.kubernetes.io/part-of: codeflare

--- a/config/prometheus/monitor.yaml
+++ b/config/prometheus/monitor.yaml
@@ -2,8 +2,6 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  labels:
-    control-plane: controller-manager
   name: manager-metrics
   namespace: system
 spec:

--- a/config/rbac/auth_proxy_service.yaml
+++ b/config/rbac/auth_proxy_service.yaml
@@ -1,8 +1,6 @@
 apiVersion: v1
 kind: Service
 metadata:
-  labels:
-    control-plane: controller-manager
   name: manager-metrics
   namespace: system
 spec:

--- a/config/rbac/auth_proxy_service.yaml
+++ b/config/rbac/auth_proxy_service.yaml
@@ -3,7 +3,7 @@ kind: Service
 metadata:
   labels:
     control-plane: controller-manager
-  name: controller-manager-metrics-service
+  name: manager-metrics
   namespace: system
 spec:
   ports:
@@ -12,4 +12,5 @@ spec:
     protocol: TCP
     targetPort: https
   selector:
-    control-plane: controller-manager
+    app.kubernetes.io/name: codeflare-operator
+    app.kubernetes.io/part-of: codeflare


### PR DESCRIPTION
This PR changes the operator deployment to use a uniquely identifying labels selector.

In order to work-around the immutability of the labels selector field, the deployment has been renamed according to OLM recommendation: https://github.com/operator-framework/operator-lifecycle-manager/issues/952#issuecomment-639657949.

This PR also leverages Kustomise `commonLabels` config, to apply [Kubernetes recommended labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/) to all resources.

Fixes #112.