### PR TITLE
Add test for custom InstaScale controller image support

### DIFF
--- a/controllers/instascale_controller_test.go
+++ b/controllers/instascale_controller_test.go
@@ -3,22 +3,26 @@ package controllers
 import (
 	"context"
 
-	mfc "github.com/manifestival/controller-runtime-client"
-	mf "github.com/manifestival/manifestival"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	mfc "github.com/manifestival/controller-runtime-client"
+	mf "github.com/manifestival/manifestival"
+
 	codeflarev1alpha1 "github.com/project-codeflare/codeflare-operator/api/v1alpha1"
 )
 
 const (
 	instascaleCRCase1             = "./testdata/instascale_test_cases/case_1.yaml"
 	instascaleCRCase2             = "./testdata/instascale_test_cases/case_2.yaml"
+	instascaleCRCase3             = "./testdata/instascale_test_cases/case_3.yaml"
 	instascaleConfigMap1          = "./testdata/instascale_test_results/case_1/configmap.yaml"
 	instascaleServiceAccount1     = "./testdata/instascale_test_results/case_1/serviceaccount.yaml"
 	instascaleClusterRole1        = "./testdata/instascale_test_results/case_1/clusterrole.yaml"
 	instascaleClusterRoleBinding1 = "./testdata/instascale_test_results/case_1/clusterrolebinding.yaml"
 	instascaleDeployment1         = "./testdata/instascale_test_results/case_1/deployment.yaml"
 	instascaleDeployment2         = "./testdata/instascale_test_results/case_2/deployment.yaml"
+	instascaleDeployment3         = "./testdata/instascale_test_results/case_3/deployment.yaml"
 )
 
 func deployInstaScale(ctx context.Context, path string, opts mf.Option) {
@@ -44,11 +48,20 @@ var _ = Describe("The Instascale Controller", func() {
 			compareClusterRoleBindings(instascaleClusterRoleBinding1, opts)
 		})
 	})
+
 	Context("In a namespace, InstaScale ControllerResources is given", func() {
 
 		It("It should deploy InstaScale with the given ControllerResources", func() {
 			deployInstaScale(ctx, instascaleCRCase2, opts)
 			compareDeployments(instascaleDeployment2, opts)
+		})
+	})
+
+	Context("When an InstaScale resource with a custom image is given", func() {
+
+		It("It should deploy InstaScale with the given controller image", func() {
+			deployInstaScale(ctx, instascaleCRCase3, opts)
+			compareDeployments(instascaleDeployment3, opts)
 		})
 	})
 })

--- a/controllers/testdata/instascale_test_cases/case_3.yaml
+++ b/controllers/testdata/instascale_test_cases/case_3.yaml
@@ -1,0 +1,6 @@
+apiVersion: codeflare.codeflare.dev/v1alpha1
+kind: InstaScale
+metadata:
+  name: example-custom-image
+spec:
+  controllerImage: quay.io/project-codeflare/instascale-controller:custom

--- a/controllers/testdata/instascale_test_results/case_3/deployment.yaml
+++ b/controllers/testdata/instascale_test_results/case_3/deployment.yaml
@@ -1,0 +1,30 @@
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: instascale-example-custom-image
+  namespace: codeflare-operator-system
+  labels:
+    app: instascale-example-custom-image
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: instascale-example-custom-image
+  template:
+    metadata:
+      labels:
+        app: instascale-example-custom-image
+    spec:
+      containers:
+        - name: instascale
+          args:
+            - "--configs-namespace=default"
+          image: quay.io/project-codeflare/instascale-controller:custom
+          resources:
+            limits:
+              cpu: '2'
+              memory: 2G
+            requests:
+              cpu: '200m'
+              memory: 200M
+      serviceAccountName: instascale-example-custom-image-sa


### PR DESCRIPTION
This follows up #120, and adds a test case covering the new `controllerImage` field of the InstaScale resource.