### PR TITLE
Extended support for referencing MCAD CRD resources

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,10 @@ INSTASCALE_VERSION ?= v0.0.4
 
 # MCAD_VERSION defines the default version of the MCAD controller
 MCAD_VERSION ?= v1.31.0
+# MCAD_REF, MCAD_REPO and MCAD_CRD define the reference to MCAD CRD resources
+MCAD_REF ?= release-${MCAD_VERSION}
+MCAD_REPO ?= github.com/project-codeflare/multi-cluster-app-dispatcher
+MCAD_CRD ?= ${MCAD_REPO}/config/crd?ref=${MCAD_REF}
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")
@@ -203,7 +207,7 @@ uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified 
 
 .PHONY: deploy
 deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
-	$(KUSTOMIZE) fn run config/crd/mcad --image gcr.io/kpt-fn/apply-setters:v0.2.0 -- MCAD_VERSION=$(MCAD_VERSION)
+	$(KUSTOMIZE) fn run config/crd/mcad --image gcr.io/kpt-fn/apply-setters:v0.2.0 -- MCAD_CRD=$(MCAD_CRD)
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
 	$(KUSTOMIZE) build config/default | kubectl apply -f -
 	git restore config/*
@@ -301,7 +305,7 @@ validate-bundle: install-operator-sdk
 .PHONY: bundle
 bundle: defaults manifests kustomize install-operator-sdk ## Generate bundle manifests and metadata, then validate generated files.
 	$(OPERATOR_SDK) generate kustomize manifests -q
-	$(KUSTOMIZE) fn run config/crd/mcad --image gcr.io/kpt-fn/apply-setters:v0.2.0 -- MCAD_VERSION=$(MCAD_VERSION)
+	$(KUSTOMIZE) fn run config/crd/mcad --image gcr.io/kpt-fn/apply-setters:v0.2.0 -- MCAD_CRD=$(MCAD_CRD)
 	cd config/manager && $(KUSTOMIZE) edit set image controller=$(IMG)
 	cd config/manifests && $(KUSTOMIZE) edit add patch --patch '[{"op":"add", "path":"/metadata/annotations/containerImage", "value": "$(IMG)" }]' --kind ClusterServiceVersion
 	cd config/manifests && $(KUSTOMIZE) edit add patch --patch '[{"op":"add", "path":"/spec/replaces", "value": "codeflare-operator.v$(PREVIOUS_VERSION)" }]' --kind ClusterServiceVersion

--- a/config/crd/mcad/kustomization.yaml
+++ b/config/crd/mcad/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- github.com/project-codeflare/multi-cluster-app-dispatcher/config/crd?ref=release-v0.0.0  # kpt-set: github.com/project-codeflare/multi-cluster-app-dispatcher/config/crd?ref=release-${MCAD_VERSION}
+- github.com/project-codeflare/multi-cluster-app-dispatcher/config/crd?ref=release-v0.0.0  # kpt-set: ${MCAD_CRD}


### PR DESCRIPTION
This PR follows up #139, to support the complete definition of the MCAD CRD resources reference, as suggested here:

https://github.com/project-codeflare/codeflare-operator/pull/139/files/26da2ebf8c15155a3a6eea1d48901d2f61a76f09#diff-a2ca4be61aa64f38fb728281ca786796093cc29b47cd1b5ba2b1d2050c3732f6
