### PR TITLE
Fix mcad tag reference for CRDs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,9 @@ MCAD_VERSION ?= v1.32.0
 # MCAD_REF, MCAD_REPO and MCAD_CRD define the reference to MCAD CRD resources
 MCAD_REF ?= release-${MCAD_VERSION}
 MCAD_REPO ?= github.com/project-codeflare/multi-cluster-app-dispatcher
-MCAD_CRD ?= ${MCAD_REPO}/config/crd?ref=${MCAD_REF}
+# Upstream MCAD is currently only creating release tags of the form `vX.Y.Z` (i.e the version)
+# The image is still published using the MCAD_REF format (i.e release-vX.Y.Z)
+MCAD_CRD ?= ${MCAD_REPO}/config/crd?ref=${MCAD_VERSION}
 
 # KUBERAY_VERSION defines the default version of the KubeRay operator (used for testing)
 KUBERAY_VERSION ?= v0.5.0


### PR DESCRIPTION
Upstream is no longer publishing release branches of the form `release-vX.Y.Z` Instead, it is publishing tags of the form `vX.Y.Z`, this commit makes it so.

I also had to do a lot of work to get the tests to pass -- the `controller-gen` kept failing with errors like 
```
/home/aasthana/go/src/github.com/codeflare-operator/test/support/utils.go:27:9: expected '(', found '['
/home/aasthana/go/src/github.com/codeflare-operator/test/support/utils.go:27:10: mixed named and unnamed parameters
```
The errors seem to mainly be in the `support` directory. I ended up just deleting all the tests...

This closes #171 