### PR TITLE
Expose CodeFlare Operator metrics endpoint

### DIFF
--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -35,5 +35,5 @@ spec:
       - name: manager
         args:
         - "--health-probe-bind-address=:8081"
-        - "--metrics-bind-address=127.0.0.1:8080"
+        - "--metrics-bind-address=0.0.0.0:8080"
         - "--leader-elect"

--- a/config/rbac/auth_proxy_service.yaml
+++ b/config/rbac/auth_proxy_service.yaml
@@ -8,7 +8,7 @@ spec:
   - name: https
     port: 8443
     protocol: TCP
-    targetPort: https
+    targetPort: 8080
   selector:
     app.kubernetes.io/name: codeflare-operator
     app.kubernetes.io/part-of: codeflare


### PR DESCRIPTION
Resolves #169 
## Exposed the CodeFlare Operator metrics endpoint
Besides exposing the endpoint, there was a need to change the `--metrics-bind-address=127.0.0.1:8080` args, from localhost to 0.0.0.0 for Prometheus to start scraping metrics successfully.

Tested with the CodeFlare Operator alert rules set on this PR: https://github.com/red-hat-data-services/odh-deployer/pull/365 

**Note:** this job was a collaborative effort between @Fiona-Waters, @dimakis, and myself @ChristianZaccaria 

## Prometheus
![image](https://github.com/project-codeflare/codeflare-operator/assets/73656840/a20d82f5-8d74-4947-907d-6e7fc3cb7c51)

