### PR TITLE
Release workflow - open a PR with changes instead of direct push

### DIFF
--- a/.github/workflows/tag-and-build.yml
+++ b/.github/workflows/tag-and-build.yml
@@ -48,9 +48,11 @@ jobs:
     # Permission required to create a release
     permissions:
       contents: write
+      pull-requests: write
 
     env:
       IMAGE_ORG_BASE: quay.io/${{ github.event.inputs.quay-organization }}
+      PR_BRANCH_NAME: adjustments-release-${{ github.event.inputs.version }}
 
     steps:
     - uses: actions/checkout@v3
@@ -132,6 +134,25 @@ jobs:
       with:
         commit_message: Update dependency versions for release ${{ github.event.inputs.version }}
         file_pattern: 'README.md controllers/defaults.go *.yaml Makefile go.mod go.sum'
+        create_branch: true
+        branch: ${{ env.PR_BRANCH_NAME }}
+
+    - name: Create a PR with code changes
+      run: |
+        GIT_BRANCH=${GITHUB_REF#refs/heads/}
+        gh pr create --base "$GIT_BRANCH" --fill --head "${{ env.PR_BRANCH_NAME }}" --label "lgtm" --label "approved"
+      env:
+        GITHUB_TOKEN: ${{ secrets.CODEFLARE_MACHINE_ACCOUNT_TOKEN }}
+
+    - name: Wait until PR with code changes is merged
+      run: |
+        timeout 3600 bash -c 'until [[ $(gh pr view '${{ env.PR_BRANCH_NAME }}' --json state --jq .state) == "MERGED" ]]; do sleep 5 && echo "$(gh pr view '${{ env.PR_BRANCH_NAME }}' --json state --jq .state)"; done'
+      env:
+        GITHUB_TOKEN: ${{ github.TOKEN }}
+
+    - name: Delete remote branch
+      run: |
+        git push origin --delete ${{ env.PR_BRANCH_NAME }}
 
     - name: Creates a release in GitHub
       run: |


### PR DESCRIPTION
# Issue link
Fixes https://github.com/project-codeflare/codeflare-operator/issues/200

# What changes have been made
<!-- describe a summary of the change, add any additional motivation and context as needed -->
Release workflow was altered to open a PR with code changes instead of pushing changes directly.

# Verification steps
<!-- Add thorough verification steps with sufficient level of detail for those without context to verify the change-->
<!-- AND Add thorough upgrade verification steps OR include a reason as to why it is not required -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->
Can be verified using own fork of codeflare-operator repository.
Setup the required secrets for your fork:
- CODEFLARE_MACHINE_ACCOUNT_TOKEN - personal access token with rights to create PRs
- QUAY_ID, QUAY_TOKEN - credentials for Quay account to push images to
Push changes in this PR into your repository fork on `main` branch.
Manually run the workflow, provide workflow parameters pointing to your own repositories (to avoid messing with official repos).

You can see results on my fork:
https://github.com/sutaakar/codeflare-operator/actions/runs/5694084278
https://github.com/sutaakar/codeflare-operator/pull/14

## Checks
- [x] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] Testing is not required for this change
