### PR TITLE
Fix: add missing --output-base option to applyconfiguration-gen

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -183,6 +183,7 @@ generate-client-files: code-generator
 		--input-dirs="github.com/project-codeflare/codeflare-operator/api/codeflare/v1alpha1" \
 		--go-header-file="hack/boilerplate.go.txt" \
 		--output-package="github.com/project-codeflare/codeflare-operator/client/applyconfiguration" \
+		--output-base="." \
 		--trim-path-prefix "github.com/project-codeflare/codeflare-operator"
 	$(CLIENT_GEN) \
 		--input="codeflare/v1alpha1" \

--- a/client/applyconfiguration/codeflare/v1alpha1/mcadspec.go
+++ b/client/applyconfiguration/codeflare/v1alpha1/mcadspec.go
@@ -33,6 +33,7 @@ type MCADSpecApplyConfiguration struct {
 	QuotaRestURL        *string                  `json:"quotaRestURL,omitempty"`
 	PodCreationTimeout  *int                     `json:"podCreationTimeout,omitempty"`
 	ControllerResources *v1.ResourceRequirements `json:"controllerResources,omitempty"`
+	ControllerImage     *string                  `json:"controllerImage,omitempty"`
 }
 
 // MCADSpecApplyConfiguration constructs an declarative configuration of the MCADSpec type for use with
@@ -102,5 +103,13 @@ func (b *MCADSpecApplyConfiguration) WithPodCreationTimeout(value int) *MCADSpec
 // If called multiple times, the ControllerResources field is set to the value of the last call.
 func (b *MCADSpecApplyConfiguration) WithControllerResources(value v1.ResourceRequirements) *MCADSpecApplyConfiguration {
 	b.ControllerResources = &value
+	return b
+}
+
+// WithControllerImage sets the ControllerImage field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the ControllerImage field is set to the value of the last call.
+func (b *MCADSpecApplyConfiguration) WithControllerImage(value string) *MCADSpecApplyConfiguration {
+	b.ControllerImage = &value
 	return b
 }


### PR DESCRIPTION
## Checks
- [x] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] Testing is not required for this change
