### PR TITLE
Upgrade Go to version 1.19

### DIFF
--- a/.github/workflows/e2e_tests.yaml
+++ b/.github/workflows/e2e_tests.yaml
@@ -57,7 +57,7 @@ jobs:
       - name: Set Go
         uses: actions/setup-go@v3
         with:
-          go-version: v1.18
+          go-version: v1.19
 
       - name: Set up gotestfmt
         uses: gotesttools/gotestfmt-action@v2

--- a/.github/workflows/olm_tests.yaml
+++ b/.github/workflows/olm_tests.yaml
@@ -56,7 +56,7 @@ jobs:
       - name: Set Go
         uses: actions/setup-go@v3
         with:
-          go-version: v1.18
+          go-version: v1.19
 
       - name: Set up gotestfmt
         uses: gotesttools/gotestfmt-action@v2

--- a/.github/workflows/precommit.yml
+++ b/.github/workflows/precommit.yml
@@ -23,6 +23,11 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Set Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: v1.19
+
       - name: Activate cache
         uses: actions/cache@v3
         with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ Here are a few things to go over before getting started with CodeFlare Operator 
 ## Environment setup
 
 The following should be installed in your working environment:
- - Go 1.18.X
+ - Go 1.19.x
    - [Download release](https://go.dev/dl/)
    - [Install Instructions](https://go.dev/doc/install)
  - [Operator SDK](https://sdk.operatorframework.io/docs/installation/)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM registry.access.redhat.com/ubi8/go-toolset:1.18.9-8 as builder
+FROM registry.access.redhat.com/ubi8/go-toolset:1.19.10-10 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/project-codeflare/codeflare-operator
 
-go 1.18
+go 1.19
 
 require (
 	github.com/go-logr/logr v1.2.4


### PR DESCRIPTION
This PR upgrades Go to version 1.19, which is the actual version required to build the current Kubernetes version, i.e., v1.26.