### PR TITLE
Add note to apply SecurityContextConstraints for OpenShift e2e tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,26 @@ The e2e tests can be executed locally by running the following commands:
    $ make setup-e2e
    ```
 
+   [!NOTE]
+   In OpenShift the KubeRay operator pod gets random user assigned. This user is then used to run Ray cluster.
+   However the random user assigned by OpenShift doesn't have rights to store dataset downloaded as part of test execution, causing tests to fail.
+   To prevent this failure on OpenShift user should enforce user 1000 for KubeRay and Ray cluster by creating this SCC in KubeRay operator namespace (replace the namespace placeholder):
+
+    ```yaml
+    kind: SecurityContextConstraints
+    apiVersion: security.openshift.io/v1
+    metadata:
+      name: run-as-ray-user
+    seLinuxContext:
+      type: MustRunAs
+    runAsUser:
+      type: MustRunAs
+      uid: 1000
+    users:
+      - 'system:serviceaccount:$(namespace):kuberay-operator'
+    ```
+
+
 4. In a separate terminal, run the e2e suite:
 
     ```bash


### PR DESCRIPTION
# Issue link
<!-- insert a link to the GitHub issue -->

# What changes have been made
<!-- describe a summary of the change, add any additional motivation and context as needed -->
Added a note about a need to create SecurityContextConstraints for KubeRay to use proper user to run Ray cluster.
Without this adjustment the tests using Ray cluster fails on OpenShift.

# Verification steps
<!-- Add thorough verification steps with sufficient level of detail for those without context to verify the change-->
<!-- AND Add thorough upgrade verification steps OR include a reason as to why it is not required -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->
Install CodeFlare operator using OLM on OpenShift.
Install test requirements by running `make setup-e2e`
Run e2e tests - the test `TestMNISTRayJobMCADRayCluster` fails.
Apply `SecurityContextConstraints` from this PR into KubeRay operator namespace, respin KubeRay pod.
Rerun the tests again - this time all tests pass.

## Checks
- [x] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [x] Manual tests
   - [ ] Testing is not required for this change
