### PR TITLE
Adjust SDK version, fix TestMNISTRayClusterSDK

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ KUBERAY_VERSION ?= v0.5.0
 RAY_VERSION ?= 2.5.0
 
 # CODEFLARE_SDK_VERSION defines the default version of the CodeFlare SDK
-CODEFLARE_SDK_VERSION ?= 0.4.4
+CODEFLARE_SDK_VERSION ?= 0.6.1
 
 # OPERATORS_REPO_ORG points to GitHub repository organization where bundle PR is opened against
 # OPERATORS_REPO_FORK_ORG points to GitHub repository fork organization where bundle build is pushed to

--- a/test/e2e/mnist_raycluster_sdk.py
+++ b/test/e2e/mnist_raycluster_sdk.py
@@ -12,13 +12,12 @@ namespace = sys.argv[1]
 cluster = Cluster(ClusterConfiguration(
     name='mnist',
     namespace=namespace,
-    min_worker=1,
-    max_worker=1,
+    num_workers=1,
     min_cpus='500m',
     max_cpus=1,
     min_memory=0.5,
     max_memory=1,
-    gpu=0,
+    num_gpus=0,
     instascale=False,
 ))
 

--- a/test/e2e/mnist_raycluster_sdk_test.go
+++ b/test/e2e/mnist_raycluster_sdk_test.go
@@ -45,6 +45,9 @@ func TestMNISTRayClusterSDK(t *testing.T) {
 		test.T().Skip("Requires https://github.com/project-codeflare/codeflare-sdk/pull/146")
 	}
 
+	// Currently blocked by https://github.com/project-codeflare/codeflare-sdk/pull/271 , remove the skip once SDK with the PR is released
+	test.T().Skip("Requires https://github.com/project-codeflare/codeflare-sdk/pull/271")
+
 	// Create a namespace
 	namespace := test.NewTestNamespace()
 

--- a/test/support/defaults.go
+++ b/test/support/defaults.go
@@ -5,7 +5,7 @@ package support
 // ***********************
 
 const (
-	CodeFlareSDKVersion = "0.4.4"
+	CodeFlareSDKVersion = "0.6.1"
 	RayVersion          = "2.5.0"
 	RayImage            = "rayproject/ray:2.5.0"
 )


### PR DESCRIPTION
Release automation doesn't raise SDK version. Will address it in next PR.

# Issue link
<!-- insert a link to the GitHub issue -->

# What changes have been made
<!-- describe a summary of the change, add any additional motivation and context as needed -->
Adjusted SDK version to latest release, applied changes in TestMNISTRayClusterSDK.

# Verification steps
<!-- Add thorough verification steps with sufficient level of detail for those without context to verify the change-->
<!-- AND Add thorough upgrade verification steps OR include a reason as to why it is not required -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->
Install CodeFlare operator using OLM on OpenShift.
Install test requirements by running make setup-e2e
Run e2e tests - TestMNISTRayClusterSDK.

## Checks
- [x] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [x] Manual tests
   - [ ] Testing is not required for this change
