### PR TITLE
Adjust CODEFLARE_SDK_VERSION in GitHub release workflow

### DIFF
--- a/.github/workflows/tag-and-build.yml
+++ b/.github/workflows/tag-and-build.yml
@@ -85,9 +85,12 @@ jobs:
         sed -i -E "s/(.*CodeFlare-SDK.*)v[0-9]+\.[0-9]+\.[0-9]+(.*)/\1${{ github.event.inputs.codeflare-sdk-version }}\2/" README.md
         sed -i -E "s/(.*InstaScale.*)v[0-9]+\.[0-9]+\.[0-9]+(.*)/\1${{ github.event.inputs.instascale-version }}\2/" README.md
 
-    - name: Adjust MCAD and InstaScale dependencies in the code
+    - name: Adjust MCAD, SDK and InstaScale dependencies in the code
       run: |
+        # Remove leading 'v'
+        CODEFLARE_SDK_VERSION=$(cut -c2- <<< ${{ github.event.inputs.codeflare-sdk-version }})
         sed -i -E "s/(.*MCAD_VERSION \?= )v[0-9]+\.[0-9]+\.[0-9]+(.*)/\1${{ github.event.inputs.mcad-version }}\2/" Makefile
+        sed -i -E "s/(.*CODEFLARE_SDK_VERSION \?= )[0-9]+\.[0-9]+\.[0-9]+(.*)/\1$CODEFLARE_SDK_VERSION\2/" Makefile
         sed -i -E "s/(.*INSTASCALE_VERSION \?= )v[0-9]+\.[0-9]+\.[0-9]+(.*)/\1${{ github.event.inputs.instascale-version }}\2/" Makefile
         sed -i -E "s/(.*instascale-controller:)v[0-9]+\.[0-9]+\.[0-9]+(.*)/\1${{ github.event.inputs.instascale-version }}\2/" controllers/testdata/instascale_test_results/case_1/deployment.yaml
         sed -i -E "s/(.*instascale-controller:)v[0-9]+\.[0-9]+\.[0-9]+(.*)/\1${{ github.event.inputs.instascale-version }}\2/" controllers/testdata/instascale_test_results/case_2/deployment.yaml


### PR DESCRIPTION
# Issue link
<!-- insert a link to the GitHub issue -->
Fixes https://github.com/project-codeflare/codeflare-operator/issues/224

# What changes have been made
<!-- describe a summary of the change, add any additional motivation and context as needed -->
Replacing CODEFLARE_SDK_VERSION value in Makefile in release GitHub workflow.

# Verification steps
<!-- Add thorough verification steps with sufficient level of detail for those without context to verify the change-->
<!-- AND Add thorough upgrade verification steps OR include a reason as to why it is not required -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->
Checkout this PR, push it to your fork of CodeFlare operator repo.
Run release workflow, providing own values as parameters.
Check the content of PR opened with code changes - it will contain SDK version update.

## Checks
- [x] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [x] Manual tests
   - [ ] Testing is not required for this change
