### PR TITLE
Enable TestMNISTRayClusterSDK test

### DIFF
--- a/test/e2e/mnist_raycluster_sdk_test.go
+++ b/test/e2e/mnist_raycluster_sdk_test.go
@@ -41,10 +41,6 @@ func TestMNISTRayClusterSDK(t *testing.T) {
 	test := With(t)
 	test.T().Parallel()
 
-	if !IsOpenShift(test) {
-		test.T().Skip("Requires https://github.com/project-codeflare/codeflare-sdk/pull/146")
-	}
-
 	// Currently blocked by https://github.com/project-codeflare/codeflare-sdk/pull/271 , remove the skip once SDK with the PR is released
 	test.T().Skip("Requires https://github.com/project-codeflare/codeflare-sdk/pull/271")
 


### PR DESCRIPTION
# Issue link
Resolves https://github.com/project-codeflare/codeflare-operator/issues/215

# What changes have been made
The TestMNISTRayClusterSDK e2e test previously only ran on OpenShift clusters as the codeflare-SDK did not support other kubernetes distributions. Now that this [PR](https://github.com/project-codeflare/codeflare-sdk/pull/146) has been merged and the codeflare-SDK dependency [updated](https://github.com/project-codeflare/codeflare-operator/commit/b325fab34bd5569a1f161ba818c90e001f509cd0) we can re-enable the test by removing the relevant call to skip the test.


# Verification steps
Run e2e tests on a non openshift cluster and make sure that TestMNISTRayClusterSDK is passing. This test is currently skipped until https://github.com/project-codeflare/codeflare-sdk/pull/271 is merged.

## Checks
- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [x] Manual tests
   - [ ] Testing is not required for this change
