### PR TITLE
Update Job names so there is no overlap between e2e and olm CI

### DIFF
--- a/.github/workflows/e2e_tests.yaml
+++ b/.github/workflows/e2e_tests.yaml
@@ -25,7 +25,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  kubernetes:
+  kubernetes-e2e:
 
     runs-on: ubuntu-20.04
 

--- a/.github/workflows/olm_tests.yaml
+++ b/.github/workflows/olm_tests.yaml
@@ -18,7 +18,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  kubernetes:
+  kubernetes-olm-upgrade:
     runs-on: ubuntu-20.04
     timeout-minutes: 60
     env:


### PR DESCRIPTION
In the last release we noticed that the PR got merged in even though the olm upgrade tests was failing (and the e2e test passed). We suspect it is due to the name of the jobs.

https://project-codeflare.slack.com/archives/C04SSHUB3GB/p1691775982411549