### PR TITLE
Test support: return default status if Route is not initialized

### DIFF
--- a/test/support/conditions.go
+++ b/test/support/conditions.go
@@ -42,6 +42,10 @@ func ConditionStatus[T conditionType](conditionType T) func(any) corev1.Conditio
 				return c.Status
 			}
 		case *routev1.Route:
+			if len(o.Status.Ingress) == 0 {
+				// Route is not initialized yet
+				break
+			}
 			if c := getRouteCondition(o.Status.Ingress[0].Conditions, routev1.RouteIngressConditionType(conditionType)); c != nil {
 				return c.Status
 			}


### PR DESCRIPTION
# Issue link
<!-- insert a link to the GitHub issue -->
<!-- If the issue is closed with this PR enter 'Closes #<issue_number>' -->

# What changes have been made
<!-- describe a summary of the change, add any additional motivation and context as needed -->
Minor fix to prevent e2e tests from failing in case Route initialization takes some time.

# Verification steps
<!-- Add thorough verification steps with sufficient level of detail for those without context to verify the change-->
<!-- AND Add thorough upgrade verification steps OR include a reason as to why it is not required -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->
N/A
(Maybe there should be unit tests for test support package...)

## Checks
- [x] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [x] Manual tests
   - [ ] Testing is not required for this change
