### PR TITLE
Test support: return error if Ray API response code doesn't match

### DIFF
--- a/test/support/ray_cluster_client.go
+++ b/test/support/ray_cluster_client.go
@@ -19,6 +19,7 @@ package support
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/url"
@@ -77,13 +78,17 @@ func (client *rayClusterClient) CreateJob(job *RayJobSetup) (response *RayJobRes
 		return
 	}
 
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf("incorrect response code: %d for creating Ray Job, response body: %s", resp.StatusCode, respData)
+	}
+
 	err = json.Unmarshal(respData, &response)
 	return
 }
 
 func (client *rayClusterClient) GetJobDetails(jobID string) (response *RayJobDetailsResponse, err error) {
-	createJobURL := client.endpoint.String() + "/api/jobs/" + jobID
-	resp, err := http.Get(createJobURL)
+	getJobDetailsURL := client.endpoint.String() + "/api/jobs/" + jobID
+	resp, err := http.Get(getJobDetailsURL)
 	if err != nil {
 		return
 	}
@@ -91,6 +96,10 @@ func (client *rayClusterClient) GetJobDetails(jobID string) (response *RayJobDet
 	respData, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return
+	}
+
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf("incorrect response code: %d for retrieving Ray Job details, response body: %s", resp.StatusCode, respData)
 	}
 
 	err = json.Unmarshal(respData, &response)
@@ -98,8 +107,8 @@ func (client *rayClusterClient) GetJobDetails(jobID string) (response *RayJobDet
 }
 
 func (client *rayClusterClient) GetJobLogs(jobID string) (logs string, err error) {
-	createJobURL := client.endpoint.String() + "/api/jobs/" + jobID + "/logs"
-	resp, err := http.Get(createJobURL)
+	getJobLogsURL := client.endpoint.String() + "/api/jobs/" + jobID + "/logs"
+	resp, err := http.Get(getJobLogsURL)
 	if err != nil {
 		return
 	}
@@ -107,6 +116,10 @@ func (client *rayClusterClient) GetJobLogs(jobID string) (logs string, err error
 	respData, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return
+	}
+
+	if resp.StatusCode != 200 {
+		return "", fmt.Errorf("incorrect response code: %d for retrieving Ray Job logs, response body: %s", resp.StatusCode, respData)
 	}
 
 	jobLogs := RayJobLogsResponse{}


### PR DESCRIPTION
# Issue link
<!-- insert a link to the GitHub issue -->
<!-- If the issue is closed with this PR enter 'Closes #<issue_number>' -->

# What changes have been made
<!-- describe a summary of the change, add any additional motivation and context as needed -->
Added a check verifying response code for Ray cluster API in test support.
If response code doesn't match the expected result then error is thrown containing response body.

# Verification steps
<!-- Add thorough verification steps with sufficient level of detail for those without context to verify the change-->
<!-- AND Add thorough upgrade verification steps OR include a reason as to why it is not required -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->
N/A

## Checks
- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] Testing is not required for this change
