### PR TITLE
Fix Instascale Version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ VERSION ?= v0.0.0-dev
 BUNDLE_VERSION ?= $(VERSION:v%=%)
 
 # INSTASCALE_VERSION defines the default version of the InstaScale controller
-INSTASCALE_VERSION ?= v.0.0.7
+INSTASCALE_VERSION ?= v0.0.7
 
 # MCAD_VERSION defines the default version of the MCAD controller
 MCAD_VERSION ?= v1.34.0

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ CodeFlare Stack Compatibility Matrix
 | CodeFlare Operator           | v0.2.0  |
 | Multi-Cluster App Dispatcher | v1.34.0 |
 | CodeFlare-SDK                | v0.7.0  |
-| InstaScale                   | v.0.0.7  |
+| InstaScale                   | v0.0.7  |
 | KubeRay                      | v0.5.0  |
 <!-- Compatibility Matrix end -->
 

--- a/controllers/defaults.go
+++ b/controllers/defaults.go
@@ -6,5 +6,5 @@ package controllers
 
 const (
 	MCADImage       = "quay.io/project-codeflare/mcad-controller:release-v1.34.0"
-	InstaScaleImage = "quay.io/project-codeflare/instascale-controller:v.0.0.7"
+	InstaScaleImage = "quay.io/project-codeflare/instascale-controller:v0.0.7"
 )

--- a/controllers/testdata/instascale_test_results/case_1/deployment.yaml
+++ b/controllers/testdata/instascale_test_results/case_1/deployment.yaml
@@ -19,7 +19,7 @@ spec:
         - name: instascale
           args:
             - "--configs-namespace=default"
-          image: quay.io/project-codeflare/instascale-controller:v.0.0.7
+          image: quay.io/project-codeflare/instascale-controller:v0.0.7
           resources:
             limits:
               cpu: '2'

--- a/controllers/testdata/instascale_test_results/case_2/deployment.yaml
+++ b/controllers/testdata/instascale_test_results/case_2/deployment.yaml
@@ -19,7 +19,7 @@ spec:
         - name: instascale
           args:
             - "--configs-namespace=default"
-          image: quay.io/project-codeflare/instascale-controller:v.0.0.7
+          image: quay.io/project-codeflare/instascale-controller:v0.0.7
           resources:
             limits:
               cpu: '1'


### PR DESCRIPTION
While deploying the codeflare stack on my osd cluster, the instascale pod did not come up and showed an `errImagePull` error. I noticed in the yaml that the image url was not as expected i.e it was v.0.0.7 instead of v0.0.7 as in Quay.io. This PR is updating the instascale image url.
