### PR TITLE
e2e tests: Reduce CPU requests for e2e test AppWrappers

### DIFF
--- a/test/e2e/mnist_pytorch_mcad_job_test.go
+++ b/test/e2e/mnist_pytorch_mcad_job_test.go
@@ -121,7 +121,7 @@ func TestMNISTPyTorchMCAD(t *testing.T) {
 							{
 								Replicas: 1,
 								Requests: corev1.ResourceList{
-									corev1.ResourceCPU:    resource.MustParse("250m"),
+									corev1.ResourceCPU:    resource.MustParse("100m"),
 									corev1.ResourceMemory: resource.MustParse("512Mi"),
 								},
 								Limits: corev1.ResourceList{

--- a/test/e2e/mnist_rayjob_mcad_raycluster_test.go
+++ b/test/e2e/mnist_rayjob_mcad_raycluster_test.go
@@ -201,7 +201,7 @@ func TestMNISTRayJobMCADRayCluster(t *testing.T) {
 							{
 								Replicas: 2,
 								Requests: corev1.ResourceList{
-									corev1.ResourceCPU:    resource.MustParse("250m"),
+									corev1.ResourceCPU:    resource.MustParse("100m"),
 									corev1.ResourceMemory: resource.MustParse("512Mi"),
 								},
 								Limits: corev1.ResourceList{


### PR DESCRIPTION
# Issue link

# What changes have been made

Reduced CPU requests for e2e test AppWrappers to accommodate changes done in MCAD v1.34.0.

Since v1.34.0 MCAD is considering pod requests and limits of already deployed other pods when computing node capacity. 
As KinD used in e2e PR checks is significantly limited in resources, most of e2e test PR checks hit the limitation of CPU requests, blocking some tests from finishing.

# Verification steps
N/A
Verification will be done by repeatedly running e2e PR check.

## Checks
- [x] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] Testing is not required for this change
