### PR TITLE
e2e support: return AppWrapper pointers instead of structs

### DIFF
--- a/test/support/mcad.go
+++ b/test/support/mcad.go
@@ -32,11 +32,18 @@ func AppWrapper(t Test, namespace *corev1.Namespace, name string) func(g gomega.
 	}
 }
 
-func AppWrappers(t Test, namespace *corev1.Namespace) func(g gomega.Gomega) []mcadv1beta1.AppWrapper {
-	return func(g gomega.Gomega) []mcadv1beta1.AppWrapper {
+func AppWrappers(t Test, namespace *corev1.Namespace) func(g gomega.Gomega) []*mcadv1beta1.AppWrapper {
+	return func(g gomega.Gomega) []*mcadv1beta1.AppWrapper {
 		aws, err := t.Client().MCAD().WorkloadV1beta1().AppWrappers(namespace.Name).List(t.Ctx(), metav1.ListOptions{})
 		g.Expect(err).NotTo(gomega.HaveOccurred())
-		return aws.Items
+
+		awsp := []*mcadv1beta1.AppWrapper{}
+		for _, v := range aws.Items {
+			v := v
+			awsp = append(awsp, &v)
+		}
+
+		return awsp
 	}
 }
 


### PR DESCRIPTION
# Issue link
<!-- insert a link to the GitHub issue -->
<!-- If the issue is closed with this PR enter 'Closes #<issue_number>' -->
Intention is to align `AppWrappers` function with `AppWrapper`, so result of both functions can be used in transforming functions.

# What changes have been made
<!-- describe a summary of the change, add any additional motivation and context as needed -->
`AppWrappers` function now returns slice of pointers on `AppWrapper` instead of slice of structs.

# Verification steps
<!-- Add thorough verification steps with sufficient level of detail for those without context to verify the change-->
<!-- AND Add thorough upgrade verification steps OR include a reason as to why it is not required -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->
Tested in ODH DW tests.

## Checks
- [x] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [x] Manual tests
   - [ ] Testing is not required for this change
