### PR TITLE
gsed support for MacOs

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,11 @@ CodeFlare Stack Compatibility Matrix
 
 Requirements:
 - GNU sed - sed is used in several Makefile command. Using macOS default sed is incompatible, so GNU sed is needed for correct execution of these commands.
+  When you have a version of the GNU sed installed on a macOS you may specify the binary using
+  ```bash
+  # brew install gnu-sed
+  make install -e SED=/usr/local/bin/gsed
+  ```
 
 ### Testing
 


### PR DESCRIPTION
# Issue link
User like to run `make install` on MacOs. Refer to [Conversation](https://project-codeflare.slack.com/archives/C04L7QH4Q84/p1695233314296039) 
# What changes have been made
Let user define sed binary

# Verification steps
For MacOs ONLY:
```bash
brew install gnu-sed
make install -e SED=/usr/local/bin/gsed
```
## Checks
- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ x] Manual tests
   - [ ] Testing is not required for this change

<!-- You can find out information on the review process at this link https://github.com/project-codeflare/codeflare/blob/develop/CONTRIBUTING.md#getting-feedback-on-your-contribution -->