### PR TITLE
Update compute resources to account for MCAD and InstaScale

### DIFF
--- a/.github/resources-olm-upgrade/subscription.yaml
+++ b/.github/resources-olm-upgrade/subscription.yaml
@@ -9,3 +9,11 @@ spec:
   name: codeflare-operator
   source: codeflare-olm-test
   sourceNamespace: olm
+  config:
+    resources:
+      limits:
+        cpu: 400m
+        memory: 128Mi
+      requests:
+        cpu: 50m
+        memory: 64Mi

--- a/.github/workflows/e2e_tests.yaml
+++ b/.github/workflows/e2e_tests.yaml
@@ -73,7 +73,7 @@ jobs:
           echo Deploying CodeFlare operator
           IMG="${REGISTRY_ADDRESS}"/codeflare-operator
           make image-push -e IMG="${IMG}"
-          make deploy -e IMG="${IMG}"
+          make deploy -e IMG="${IMG}" -e ENV="e2e"
           kubectl wait --timeout=120s --for=condition=Available=true deployment -n openshift-operators codeflare-operator-manager
 
           echo Setting up CodeFlare stack

--- a/.github/workflows/olm_tests.yaml
+++ b/.github/workflows/olm_tests.yaml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-20.04
     timeout-minutes: 60
     env:
-      OLM_VERSION: v0.24.0
+      OLM_VERSION: v0.25.0
       VERSION: "v0.0.0-ghaction"  # Need to supply some semver version for bundle to be properly generated
       CATALOG_BASE_IMG: "registry.access.redhat.com/redhat/community-operator-index:v4.13"
       CODEFLARE_TEST_TIMEOUT_SHORT: "1m"

--- a/Makefile
+++ b/Makefile
@@ -87,6 +87,10 @@ IMG ?= ${IMAGE_TAG_BASE}:${VERSION}
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.24.2
 
+# The target deployment environment, that corresponds to the Kustomize directory
+# used to build the manifests.
+ENV ?= default
+
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
 GOBIN=$(shell go env GOPATH)/bin
@@ -202,13 +206,13 @@ uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified 
 deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
 	$(SED) -i -E "s|(- )\${MCAD_REPO}.*|\1\${MCAD_CRD}|" config/crd/mcad/kustomization.yaml
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
-	$(KUSTOMIZE) build config/default | kubectl apply -f -
+	$(KUSTOMIZE) build config/${ENV} | kubectl apply -f -
 	git restore config/*
 
 .PHONY: undeploy
 undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
 	$(SED) -i -E "s|(- )\${MCAD_REPO}.*|\1\${MCAD_CRD}|" config/crd/mcad/kustomization.yaml
-	$(KUSTOMIZE) build config/default | kubectl delete --ignore-not-found=$(ignore-not-found) -f -
+	$(KUSTOMIZE) build config/${ENV} | kubectl delete --ignore-not-found=$(ignore-not-found) -f -
 	git restore config/*
 
 ##@ Build Dependencies

--- a/config/e2e/kustomization.yaml
+++ b/config/e2e/kustomization.yaml
@@ -1,0 +1,9 @@
+bases:
+- ../default
+
+patches:
+  - target:
+      kind: Deployment
+      name: manager
+      namespace: system
+    path: patch_resources.yaml

--- a/config/e2e/patch_resources.yaml
+++ b/config/e2e/patch_resources.yaml
@@ -1,0 +1,2 @@
+- op: remove
+  path: /spec/template/spec/containers/0/resources

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -65,10 +65,10 @@ spec:
           periodSeconds: 10
         resources:
           limits:
-            cpu: 500m
-            memory: 128Mi
+            cpu: "1"
+            memory: 1Gi
           requests:
-            cpu: 10m
-            memory: 64Mi
+            cpu: "1"
+            memory: 1Gi
       serviceAccountName: controller-manager
       terminationGracePeriodSeconds: 10


### PR DESCRIPTION
Following up #216, this PR update the operator compute resources so it better accounts for both MCAD and InstaScale controllers requirements.

It configures the resources so that the operator is assigned with the [guaranteed QoS class](https://kubernetes.io/docs/concepts/workloads/pods/pod-qos/#guaranteed), and with enough resources, so it performs acceptably by default.

Closes #280.
