### PR TITLE
Add missing OpenShift Config API to runtime scheme

### DIFF
--- a/main.go
+++ b/main.go
@@ -49,6 +49,7 @@ import (
 	"sigs.k8s.io/yaml"
 
 	configv1 "github.com/openshift/api/config/v1"
+	machinev1beta1 "github.com/openshift/api/machine/v1beta1"
 
 	"github.com/project-codeflare/codeflare-operator/pkg/config"
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
@@ -63,9 +64,12 @@ var (
 
 func init() {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+	// MCAD
 	utilruntime.Must(mcadv1beta1.AddToScheme(scheme))
 	utilruntime.Must(quotasubtreev1.AddToScheme(scheme))
+	// InstaScale
 	utilruntime.Must(configv1.Install(scheme))
+	utilruntime.Must(machinev1beta1.Install(scheme))
 }
 
 func main() {

--- a/main.go
+++ b/main.go
@@ -48,6 +48,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/yaml"
 
+	configv1 "github.com/openshift/api/config/v1"
+
 	"github.com/project-codeflare/codeflare-operator/pkg/config"
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
@@ -63,6 +65,7 @@ func init() {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 	utilruntime.Must(mcadv1beta1.AddToScheme(scheme))
 	utilruntime.Must(quotasubtreev1.AddToScheme(scheme))
+	utilruntime.Must(configv1.Install(scheme))
 }
 
 func main() {


### PR DESCRIPTION
Add the OpenShift Config API required by InstaScale to the runtime scheme, as discussed in #304.

It also adds the Machine API, that'll be required by project-codeflare/instascale#89.