### PR TITLE
fix: codeflare-operator e2e tests not passing

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,10 @@ The e2e tests can be executed locally by running the following commands:
       - 'system:serviceaccount:$(namespace):kuberay-operator'
     ```
 
-4. In a separate terminal, run the e2e suite:
+4.  In a separate terminal, set your output directory for test files, and run the e2e suite:
+    ```bash
+    export CODEFLARE_TEST_OUTPUT_DIR=<your_output_directory>
+    ```
 
     ```bash
     make test-e2e

--- a/test/e2e/mnist_pytorch_mcad_job_test.go
+++ b/test/e2e/mnist_pytorch_mcad_job_test.go
@@ -77,15 +77,23 @@ func TestMNISTPyTorchMCAD(t *testing.T) {
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{
 						{
-							Name:    "job",
-							Image:   GetPyTorchImage(),
+							Name:  "job",
+							Image: GetPyTorchImage(),
+							Env: []corev1.EnvVar{
+								corev1.EnvVar{Name: "PYTHONUSERBASE", Value: "/workdir"},
+							},
 							Command: []string{"/bin/sh", "-c", "pip install -r /test/requirements.txt && torchrun /test/mnist.py"},
 							VolumeMounts: []corev1.VolumeMount{
 								{
 									Name:      "test",
 									MountPath: "/test",
 								},
+								{
+									Name:      "workdir",
+									MountPath: "/workdir",
+								},
 							},
+							WorkingDir: "/workdir",
 						},
 					},
 					Volumes: []corev1.Volume{
@@ -97,6 +105,12 @@ func TestMNISTPyTorchMCAD(t *testing.T) {
 										Name: config.Name,
 									},
 								},
+							},
+						},
+						{
+							Name: "workdir",
+							VolumeSource: corev1.VolumeSource{
+								EmptyDir: &corev1.EmptyDirVolumeSource{},
 							},
 						},
 					},

--- a/test/e2e/mnist_raycluster_sdk_test.go
+++ b/test/e2e/mnist_raycluster_sdk_test.go
@@ -160,14 +160,22 @@ func TestMNISTRayClusterSDK(t *testing.T) {
 							Name: "test",
 							// FIXME: switch to base Python image once the dependency on OpenShift CLI is removed
 							// See https://github.com/project-codeflare/codeflare-sdk/pull/146
-							Image:   "quay.io/opendatahub/notebooks:jupyter-minimal-ubi8-python-3.8-4c8f26e",
+							Image: "quay.io/opendatahub/notebooks:jupyter-minimal-ubi8-python-3.8-4c8f26e",
+							Env: []corev1.EnvVar{
+								corev1.EnvVar{Name: "PYTHONUSERBASE", Value: "/workdir"},
+							},
 							Command: []string{"/bin/sh", "-c", "pip install codeflare-sdk==" + GetCodeFlareSDKVersion() + " && cp /test/* . && python mnist_raycluster_sdk.py" + " " + namespace.Name},
 							VolumeMounts: []corev1.VolumeMount{
 								{
 									Name:      "test",
 									MountPath: "/test",
 								},
+								{
+									Name:      "workdir",
+									MountPath: "/workdir",
+								},
 							},
+							WorkingDir: "/workdir",
 						},
 					},
 					Volumes: []corev1.Volume{
@@ -179,6 +187,12 @@ func TestMNISTRayClusterSDK(t *testing.T) {
 										Name: config.Name,
 									},
 								},
+							},
+						},
+						{
+							Name: "workdir",
+							VolumeSource: corev1.VolumeSource{
+								EmptyDir: &corev1.EmptyDirVolumeSource{},
 							},
 						},
 					},


### PR DESCRIPTION
# Issue link
#313

# What changes have been made
Using the 'PYTHONUSERBASE' environment variable, to point to the emptyDir volume mount for mnist_pytorch_mcad_job_test and mnist_raycluster_sdk_test

Updated the readme to provide instructions to setting the CODEFLARE_TEST_OUTPUT_DIR when running e2e tests locally.

# Verification steps
Follow the end to end test instructions, and they should now pass, and complete the runthrough :)

## Checks
- [x] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [ ] Manual tests
   - [ ] Testing is not required for this change

<!-- You can find out information on the review process at this link https://github.com/project-codeflare/codeflare/blob/develop/CONTRIBUTING.md#getting-feedback-on-your-contribution -->