### PR TITLE
add: Print out parameters used in CodeFlare release workflow

### DIFF
--- a/.github/workflows/project-codeflare-release.yml
+++ b/.github/workflows/project-codeflare-release.yml
@@ -37,6 +37,22 @@ on:
         default: 'redhat-openshift-ecosystem'
 
 jobs:
+  release-parameters:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Release Parameters
+      run: |
+        echo "Below are the release parameters set for the workflow:"
+        echo "Operator Version: ${{ github.event.inputs.operator-version }}"
+        echo "Replaces: ${{ github.event.inputs.replaces }}"
+        echo "MCAD Version: ${{ github.event.inputs.mcad-version }}"
+        echo "CodeFlare SDK Version: ${{ github.event.inputs.codeflare-sdk-version }}"
+        echo "InstaScale Version: ${{ github.event.inputs.instascale-version }}"
+        echo "Is Stable: ${{ github.event.inputs.is-stable }}"
+        echo "CodeFlare Repository Organization: ${{ github.event.inputs.codeflare-repository-organization }}"
+        echo "Quay Organization: ${{ github.event.inputs.quay-organization }}"
+        echo "Community Operators Prod Organization: ${{ github.event.inputs.community-operators-prod-organization }}"
+
   release-mcad:
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
# Issue link
closes https://github.com/project-codeflare/codeflare-operator/issues/331

# What changes have been made
This pr adds an additional job to the project codeflare release workflow, which will log the parameters set for the workflow. 

The parameters will now be visible form `Actions`, `Project CodeFlare Release` , and under the heading `Jobs`.

My reasoning to the separation of these logs into a Job, rather than in one of the logs of an already present job, is that this separation allows for the logs to be displayed even if any particular job is skipped.

ie) From Project CodeFlare Release 2, the parameters are visible in [release-codeflare-operator](https://github.com/project-codeflare/codeflare-operator/actions/runs/5788579591/job/15716454551) due to the tag-and-build command:

```
Run gh workflow run tag-and-build.yml --repo project-codeflare/codeflare-operator --ref refs/heads/main --field is-stable=true --field version=v0.1.0 --field replaces=v0.0.6 --field mcad-version=v1.33.0 --field codeflare-sdk-version=v0.6.1 --field instascale-version=v0.0.6 --field quay-organization=project-codeflare --field community-operators-prod-fork-organization=project-codeflare --field community-operators-prod-organization=redhat-openshift-ecosystem
```

However, in [Project Codeflare Release 6](https://github.com/project-codeflare/codeflare-operator/actions/runs/6486614180) where the `release-codeflare-operator` is skipped, one would be unable to gather these values. 


## Checks
- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] Testing is not required for this change

<!-- You can find out information on the review process at this link https://github.com/project-codeflare/codeflare/blob/develop/CONTRIBUTING.md#getting-feedback-on-your-contribution -->