### PR TITLE
Add ClusterRole and ClusterRoleBinding for KubeRay

### DIFF
--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -11,3 +11,5 @@ resources:
 - instascale_role_binding.yaml
 - leader_election_role.yaml
 - leader_election_role_binding.yaml
+- mcad-controller-ray-clusterrolebinding.yaml
+- mcad-controller-ray-clusterrole.yaml

--- a/config/rbac/mcad-controller-ray-clusterrole.yaml
+++ b/config/rbac/mcad-controller-ray-clusterrole.yaml
@@ -1,0 +1,31 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: mcad-controller-ray-clusterrole
+rules:
+- apiGroups:
+  - ray.io
+  resources:
+  - rayclusters
+  - rayclusters/finalizers
+  - rayclusters/status
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - route.openshift.io
+  resources:
+  - routes
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch

--- a/config/rbac/mcad-controller-ray-clusterrolebinding.yaml
+++ b/config/rbac/mcad-controller-ray-clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: mcad-controller-ray-clusterrolebinding
+subjects:
+  - kind: ServiceAccount
+    name: codeflare-operator-controller-manager
+    namespace: openshift-operators
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: mcad-controller-ray-clusterrole


### PR DESCRIPTION
# Issue link
Closes #337 

# What changes have been made
ClusterRole and ClusterRoleBinding for KubeRay have been added.

# Verification steps
Install following the [quick start](https://github.com/opendatahub-io/distributed-workloads/blob/main/Quick-Start-ODH-V2.md) and confirm that the ClusterRole and ClusterRole binding are being applied as expected and that there are no `rayclusters` errors in the CodeFlare Operator logs.

## Checks
- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [X] Manual tests
   - [ ] Testing is not required for this change

<!-- You can find out information on the review process at this link https://github.com/project-codeflare/codeflare/blob/develop/CONTRIBUTING.md#getting-feedback-on-your-contribution -->