### PR TITLE
Set security context on test pod to avoid pod security warning

### DIFF
--- a/test/e2e/mnist_raycluster_sdk_test.go
+++ b/test/e2e/mnist_raycluster_sdk_test.go
@@ -175,6 +175,16 @@ func TestMNISTRayClusterSDK(t *testing.T) {
 								},
 							},
 							WorkingDir: "/workdir",
+							SecurityContext: &corev1.SecurityContext{
+								AllowPrivilegeEscalation: Ptr(false),
+								SeccompProfile: &corev1.SeccompProfile{
+									Type: "RuntimeDefault",
+								},
+								Capabilities: &corev1.Capabilities{
+									Drop: []corev1.Capability{"ALL"},
+								},
+								RunAsNonRoot: Ptr(true),
+							},
 						},
 					},
 					Volumes: []corev1.Volume{


### PR DESCRIPTION
# Issue link
<!-- insert a link to the GitHub issue -->
<!-- If the issue is closed with this PR enter 'Closes #<issue_number>' -->
closes https://github.com/project-codeflare/codeflare-operator/issues/328
# What changes have been made
<!-- describe a summary of the change, add any additional motivation and context as needed -->
Added security context on the test Pod to avoid PodSecurity warning when running TestMNISTRayClusterSDK on OpenShift FIPS enabled cluster
# Verification steps
<!-- Add thorough verification steps with sufficient level of detail for those without context to verify the change-->
<!-- AND Add thorough upgrade verification steps OR include a reason as to why it is not required -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->
1.Setup the codeflare operator on cluster openshift with FIPS enabled mode(https://docs.openshift.com/container-platform/4.12/installing/installing-fips.html) 
2. Run test TestMNISTRayClusterSDK and check whether warnings are showing while running the test 
Note : Tested this test by  removing skip  in local on openshift cluster with  FIPS enable mode
## Checks
- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] Testing is not required for this change

<!-- You can find out information on the review process at this link https://github.com/project-codeflare/codeflare/blob/develop/CONTRIBUTING.md#getting-feedback-on-your-contribution -->