### PR TITLE
Updated CFO sync and tag-build workflows

### DIFF
--- a/.github/workflows/odh-fork-sync.yml
+++ b/.github/workflows/odh-fork-sync.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - name: Sync-fork
         run: |
-          gh workflow run sync-fork.yaml -R github.com/opendatahub-io/codeflare-operator -r main
+          gh workflow run sync-fork.yaml --repo github.com/opendatahub-io/codeflare-operator --ref main
         env:
           GITHUB_TOKEN: ${{ secrets.CODEFLARE_MACHINE_ACCOUNT_TOKEN }}
         shell:

--- a/.github/workflows/odh-fork-sync.yml
+++ b/.github/workflows/odh-fork-sync.yml
@@ -1,7 +1,7 @@
 name: Call sync on OpenDataHub CFO fork sync
 on:
   release:
-    types: 
+    types:
       [published]
   workflow_dispatch:
 

--- a/.github/workflows/odh-fork-sync.yml
+++ b/.github/workflows/odh-fork-sync.yml
@@ -1,7 +1,8 @@
 name: Call sync on OpenDataHub CFO fork sync
 on:
   release:
-    types: [published]
+    types: 
+      [published]
   workflow_dispatch:
 
 jobs:
@@ -9,7 +10,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Sync-fork
-        env:
-          GITHUB_TOKEN: ${{ secrets.CODEFLARE_MACHINE_ACCOUNT_TOKEN }}
         run: |
           gh workflow run sync-fork.yaml -R github.com/opendatahub-io/codeflare-operator -r main
+        env:
+          GITHUB_TOKEN: ${{ secrets.CODEFLARE_MACHINE_ACCOUNT_TOKEN }}
+        shell:
+          bash

--- a/.github/workflows/odh-fork-sync.yml
+++ b/.github/workflows/odh-fork-sync.yml
@@ -2,7 +2,7 @@ name: Call sync on OpenDataHub CFO fork sync
 on:
   release:
     types:
-      [published]
+      - published
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/tag-and-build.yml
+++ b/.github/workflows/tag-and-build.yml
@@ -171,5 +171,5 @@ jobs:
         gh release edit ${{ github.event.inputs.version }} --notes-file release-notes.md
         rm release-notes.md
       env:
-        GITHUB_TOKEN: ${{ github.TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.CODEFLARE_MACHINE_ACCOUNT_TOKEN }}
       shell: bash


### PR DESCRIPTION
# Issue link
<!-- insert a link to the GitHub issue -->
<!-- If the issue is closed with this PR enter 'Closes #<issue_number>' -->
Closes: #366 
# What changes have been made
<!-- describe a summary of the change, add any additional motivation and context as needed -->
During the release on Friday the `odh-fork-sync` workflow did not trigger. I suspect the issue is similar to this one [here](https://github.com/orgs/community/discussions/26875#discussioncomment-3253761) . 
I updated the `tag-and-build` workflow to use the `CODEFLARE_MACHINE_ACCOUNT_TOKEN` instead of the `github.TOKEN` which could solve our issue.

I also made changes to how `odh-sync-fork` is set up.
# Verification steps
<!-- Add thorough verification steps with sufficient level of detail for those without context to verify the change-->
<!-- AND Add thorough upgrade verification steps OR include a reason as to why it is not required -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->
I tested this out using example workflows and I got a workflow to trigger on a published release using the PAT token.
## Checks
- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [x] Manual tests
   - [ ] Testing is not required for this change

<!-- You can find out information on the review process at this link https://github.com/project-codeflare/codeflare/blob/develop/CONTRIBUTING.md#getting-feedback-on-your-contribution -->