### PR TITLE
Use CGO_ENABLED=1 for FIPS compliance reasons

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ COPY pkg/ pkg/
 
 # Build
 USER root
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager main.go
+RUN CGO_ENABLED=1 GOOS=linux GOARCH=amd64 go build -a -o manager main.go
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.8
 WORKDIR /


### PR DESCRIPTION
Closes https://github.com/red-hat-data-services/codeflare-operator/issues/4

cc @jbusche 

The failures have gone away, but I'm seeing the following warning now:

```
---- Warning Report
+------------------------+-----------------+-----------------------------------------------------------------+---------------------------------------------------+
| OPERATOR NAME          | EXECUTABLE NAME | STATUS                                                          | IMAGE                                             |
+------------------------+-----------------+-----------------------------------------------------------------+---------------------------------------------------+
| ubi8-minimal-container | /manager        | go binary has no build tags set (should have strictfipsruntime) | quay.io/anishasthana/codeflare-operator:enablecgo |
+------------------------+-----------------+-----------------------------------------------------------------+---------------------------------------------------+
---- Successful run with warnings
```

Image is up at quay.io/anishasthana/codeflare-operator:enablecgo.
