### PR TITLE
Add build info to logs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -159,7 +159,14 @@ modules: ## Update Go dependencies.
 
 .PHONY: build
 build: modules fmt vet ## Build manager binary.
-	go build -ldflags "-X 'main.BuildVersion=$(BUILD_VERSION)' -X 'main.BuildDate=$(BUILD_DATE)'" -o bin/manager main.go
+	go build \
+		-ldflags " \
+			-X 'main.OperatorVersion=$(BUILD_VERSION)' \
+			-X 'main.McadVersion=$(MCAD_VERSION)'  \
+			-X 'main.InstaScaleVersion=$(INSTASCALE_VERSION)' \
+			-X 'main.BuildDate=$(BUILD_DATE)' \
+		" \
+		-o bin/manager main.go
 
 .PHONY: run
 run: modules manifests fmt vet ## Run a controller from your host.

--- a/main.go
+++ b/main.go
@@ -58,8 +58,10 @@ import (
 )
 
 var (
-	scheme   = runtime.NewScheme()
-	setupLog = ctrl.Log.WithName("setup")
+	scheme       = runtime.NewScheme()
+	setupLog     = ctrl.Log.WithName("setup")
+	BuildVersion = "UNKNOWN"
+	BuildDate    = "UNKNOWN"
 )
 
 func init() {
@@ -85,6 +87,7 @@ func main() {
 	zapOptions.BindFlags(flag.CommandLine)
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&zapOptions)))
+	setupLog.Info("Build info", "version", BuildVersion, "date", BuildDate)
 
 	ctx := ctrl.SetupSignalHandler()
 

--- a/main.go
+++ b/main.go
@@ -58,10 +58,12 @@ import (
 )
 
 var (
-	scheme       = runtime.NewScheme()
-	setupLog     = ctrl.Log.WithName("setup")
-	BuildVersion = "UNKNOWN"
-	BuildDate    = "UNKNOWN"
+	scheme            = runtime.NewScheme()
+	setupLog          = ctrl.Log.WithName("setup")
+	OperatorVersion   = "UNKNOWN"
+	McadVersion       = "UNKNOWN"
+	InstaScaleVersion = "UNKNOWN"
+	BuildDate         = "UNKNOWN"
 )
 
 func init() {
@@ -87,7 +89,12 @@ func main() {
 	zapOptions.BindFlags(flag.CommandLine)
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&zapOptions)))
-	setupLog.Info("Build info", "version", BuildVersion, "date", BuildDate)
+	setupLog.Info("Build info",
+		"operatorVersion", OperatorVersion,
+		"mcadVersion", McadVersion,
+		"instaScaleVersion", InstaScaleVersion,
+		"date", BuildDate,
+	)
 
 	ctx := ctrl.SetupSignalHandler()
 


### PR DESCRIPTION
# Issue link
<!-- insert a link to the GitHub issue -->
<!-- If the issue is closed with this PR enter 'Closes #<issue_number>' -->

# What changes have been made
<!-- describe a summary of the change, add any additional motivation and context as needed -->
This PR adds a log line with the build version and build date of the CFO.
Knowing the build version and build date is useful when debugging historical logs and correlating them with the actual code that produced them.

build version format:
```
<tag>[-<sha>][-dirty]
```

`<tag>`: The name of the most recent tag (stripping the prefix 'v')
`<sha>`: If HEAD is not pointed to a tag, then the hash of HEAD is added.
`dirty`: If the repository contains any changes, "-dirty" is added.

Note: Once approved, I think it will be beneficial to add a similar PR to MCAD and will be happy to do that.


# Verification steps
<!-- Add thorough verification steps with sufficient level of detail for those without context to verify the change-->
<!-- AND Add thorough upgrade verification steps OR include a reason as to why it is not required -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->

Build and run:
```
make build && ./bin/manager
```

The first log line should look like:
```
2023-11-13T17:27:45+02:00       INFO    setup   Build info      {"version": "1.0.0-7991ad5", "date": "2023-11-13 17:27"}
```

Running without `make build` should yield:
```
$ go run main.go
2023-11-13T17:53:52+02:00       INFO    setup   Build info      {"version": "UNKNOWN", "date": "UNKNOWN"}
```


## Checks
- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] Testing is not required for this change

<!-- You can find out information on the review process at this link https://github.com/project-codeflare/codeflare/blob/develop/CONTRIBUTING.md#getting-feedback-on-your-contribution -->