### PR TITLE
Prase command line flags

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -46,7 +46,7 @@ require (
 	github.com/go-openapi/swag v0.22.3 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang-jwt/jwt/v4 v4.4.3 // indirect
-	github.com/golang/glog v1.1.0 // indirect
+	github.com/golang/glog v1.1.2 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/google/cel-go v0.12.6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -159,8 +159,8 @@ github.com/golang-jwt/jwt/v4 v4.4.3 h1:Hxl6lhQFj4AnOX6MLrsCb/+7tCj7DxP7VA+2rDIq5
 github.com/golang-jwt/jwt/v4 v4.4.3/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/glog v1.0.0/go.mod h1:EWib/APOK0SL3dFbYqvxE3UYd8E6s1ouQ7iEp/0LWV4=
-github.com/golang/glog v1.1.0 h1:/d3pCKDPWNnvIWe0vVUpNP32qc8U3PDVxySP/y360qE=
-github.com/golang/glog v1.1.0/go.mod h1:pfYeQZ3JWZoXTV5sFc986z3HTpwQs9At6P4ImfuP3NQ=
+github.com/golang/glog v1.1.2 h1:DVjP2PbBOzHyzA+dn3WhHIq4NdVu3Q+pvivFICf/7fo=
+github.com/golang/glog v1.1.2/go.mod h1:zR+okUeTbrL6EL3xHUDxZuEtGv04p5shwip1+mL/rLQ=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=

--- a/main.go
+++ b/main.go
@@ -81,6 +81,7 @@ func main() {
 	flag.StringVar(&configMapName, "config", "codeflare-operator-config",
 		"The name of the ConfigMap to load the operator configuration from. "+
 			"If it does not exist, the operator will create and initialise it.")
+	flag.Parse()
 
 	zapOptions := zap.Options{
 		Development: true,

--- a/main.go
+++ b/main.go
@@ -81,13 +81,13 @@ func main() {
 	flag.StringVar(&configMapName, "config", "codeflare-operator-config",
 		"The name of the ConfigMap to load the operator configuration from. "+
 			"If it does not exist, the operator will create and initialise it.")
-	flag.Parse()
 
 	zapOptions := zap.Options{
 		Development: true,
 		TimeEncoder: zapcore.TimeEncoderOfLayout(time.RFC3339),
 	}
 	zapOptions.BindFlags(flag.CommandLine)
+	flag.Parse()
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&zapOptions)))
 	setupLog.Info("Build info",


### PR DESCRIPTION
# Issue link
<!-- insert a link to the GitHub issue -->
<!-- If the issue is closed with this PR enter 'Closes #<issue_number>' -->

# What changes have been made
<!-- describe a summary of the change, add any additional motivation and context as needed -->
- Added a call to `flag.Parse()` to parse command line flags.
- Updated `glog` module to fix panic on help message (`./bin/manager --help`).

# Verification steps
<!-- Add thorough verification steps with sufficient level of detail for those without context to verify the change-->
<!-- AND Add thorough upgrade verification steps OR include a reason as to why it is not required -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->

Running `bin/manager --help` should output:
```
Usage of bin/manager:
  -alsologtostderr
     log to standard error as well as files
  -config string
     The name of the ConfigMap to load the operator configuration from. If it does not exist, the operator will create and initialise it. (default "codeflare-operator-config")
  -kubeconfig string
     Paths to a kubeconfig. Only required if out-of-cluster.
  -log_backtrace_at value
     when logging hits line file:N, emit a stack trace
  -log_dir string
     If non-empty, write log files in this directory
  -log_link string
     If non-empty, add symbolic links in this directory to the log files
  -logbuflevel int
     Buffer log messages logged at this level or lower (-1 means don't buffer; 0 means buffer INFO only; ...). Has limited applicability on non-prod platforms.
  -logtostderr
     log to standard error instead of files
  -stderrthreshold value
     logs at or above this threshold go to stderr (default 2)
  -v value
     log level for V logs
  -vmodule value
     comma-separated list of pattern=N settings for file-filtered logging
```

## Checks
- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] Testing is not required for this change

<!-- You can find out information on the review process at this link https://github.com/project-codeflare/codeflare/blob/develop/CONTRIBUTING.md#getting-feedback-on-your-contribution -->