### PR TITLE
e2e: Fix deployment namespace

### DIFF
--- a/config/e2e/kustomization.yaml
+++ b/config/e2e/kustomization.yaml
@@ -1,3 +1,5 @@
+namespace: openshift-operators
+
 bases:
 - ../default
 


### PR DESCRIPTION
Follows up #400 to set the namespace at the top-level overlay used by the e2e tests.