### PR TITLE
Raise SDK e2e test timeout in Python script

### DIFF
--- a/test/e2e/mnist_raycluster_sdk.py
+++ b/test/e2e/mnist_raycluster_sdk.py
@@ -62,7 +62,7 @@ job = jobdef.submit(cluster)
 
 done = False
 time = 0
-timeout = 300
+timeout = 900
 while not done:
     status = job.status()
     if is_terminal(status.state):


### PR DESCRIPTION
# Issue link
<!-- insert a link to the GitHub issue -->
<!-- If the issue is closed with this PR enter 'Closes #<issue_number>' -->
N/A
Related to slow environment issues detected in https://github.com/opendatahub-io/codeflare-operator/pull/31

# What changes have been made
<!-- describe a summary of the change, add any additional motivation and context as needed -->
Raise a timeout in SDK e2e test Python script to accommodate slower environment.

# Verification steps
<!-- Add thorough verification steps with sufficient level of detail for those without context to verify the change-->
<!-- AND Add thorough upgrade verification steps OR include a reason as to why it is not required -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->
N/A
Could be verified by running `TestMNISTRayJobMCADRayCluster` on slower environment.

## Checks
- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] Testing is not required for this change

<!-- You can find out information on the review process at this link https://github.com/project-codeflare/codeflare/blob/develop/CONTRIBUTING.md#getting-feedback-on-your-contribution -->