### PR TITLE
Remove accidental prefix for service account for mcad-controller-ray-…

### DIFF
--- a/config/rbac/mcad-controller-ray-clusterrolebinding.yaml
+++ b/config/rbac/mcad-controller-ray-clusterrolebinding.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mcad-controller-ray-clusterrolebinding
 subjects:
   - kind: ServiceAccount
-    name: codeflare-operator-controller-manager
+    name: controller-manager
     namespace: system
 roleRef:
   apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
…clusterrolebinding

# Issue link
<!-- insert a link to the GitHub issue -->
<!-- If the issue is closed with this PR enter 'Closes #<issue_number>' -->
Fixes https://github.com/project-codeflare/codeflare-operator/issues/420

# What changes have been made
<!-- describe a summary of the change, add any additional motivation and context as needed -->
Service account name in `mcad-controller-ray-clusterrolebinding` accidentally contained `codeflare-operator-` prefix, this prefix should be provided later, during kustomize build.
As a result the kustomize build using default profile wasn't able to replace Service account namespace, causing CFO deployed by default profile to fail processing Ingress resource.

# Verification steps
<!-- Add thorough verification steps with sufficient level of detail for those without context to verify the change-->
<!-- AND Add thorough upgrade verification steps OR include a reason as to why it is not required -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->
Deploy CFO using `make deploy -e IMG=quay.io/project-codeflare/codeflare-operator:v1.0.0-rc.4`. With this fix the `mcad-controller-ray-clusterrolebinding` CRB resource points to `codeflare-operator-controller-manager` SA using proper namespace `openshift-operators`.

## Checks
- [x] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [x] Manual tests
   - [ ] Testing is not required for this change

<!-- You can find out information on the review process at this link https://github.com/project-codeflare/codeflare/blob/develop/CONTRIBUTING.md#getting-feedback-on-your-contribution -->