### PR TITLE
e2e tests: Export all KinD logs

### DIFF
--- a/.github/workflows/e2e_tests.yaml
+++ b/.github/workflows/e2e_tests.yaml
@@ -92,6 +92,12 @@ jobs:
           echo "Printing KubeRay operator logs"
           kubectl logs -n ray-system --tail -1 -l app.kubernetes.io/name=kuberay | tee ${CODEFLARE_TEST_OUTPUT_DIR}/kuberay.log
 
+      - name: Export all KinD pod logs
+        uses: ./common/github-actions/kind-export-logs
+        if: always() && steps.deploy.outcome == 'success'
+        with:
+          output-directory: ${CODEFLARE_TEST_OUTPUT_DIR}
+
       - name: Upload logs
         uses: actions/upload-artifact@v3
         if: always() && steps.deploy.outcome == 'success'

--- a/.github/workflows/olm_tests.yaml
+++ b/.github/workflows/olm_tests.yaml
@@ -185,6 +185,12 @@ jobs:
           echo "Printing KubeRay operator logs"
           kubectl logs -n ray-system --tail -1 -l app.kubernetes.io/name=kuberay | tee ${CODEFLARE_TEST_OUTPUT_DIR}/kuberay.log
 
+      - name: Export all KinD pod logs
+        uses: ./common/github-actions/kind-export-logs
+        if: always() && steps.deploy.outcome == 'success'
+        with:
+          output-directory: ${CODEFLARE_TEST_OUTPUT_DIR}
+
       - name: Upload logs
         uses: actions/upload-artifact@v3
         if: always() && steps.deploy.outcome == 'success'


### PR DESCRIPTION
# Issue link
<!-- insert a link to the GitHub issue -->
<!-- If the issue is closed with this PR enter 'Closes #<issue_number>' -->
Closes https://github.com/project-codeflare/codeflare-operator/issues/436

# What changes have been made
<!-- describe a summary of the change, add any additional motivation and context as needed -->
Storing all KinD pod logs as PR check job artifact.

# Verification steps
<!-- Add thorough verification steps with sufficient level of detail for those without context to verify the change-->
<!-- AND Add thorough upgrade verification steps OR include a reason as to why it is not required -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->
Check PR check job artifacts - all KinD pod logs are stored there.

## Checks
- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] Testing is not required for this change

<!-- You can find out information on the review process at this link https://github.com/project-codeflare/codeflare/blob/develop/CONTRIBUTING.md#getting-feedback-on-your-contribution -->