### PR TITLE
Fix MCAD version in Makefile

### DIFF
--- a/.github/workflows/tag-and-build.yml
+++ b/.github/workflows/tag-and-build.yml
@@ -109,6 +109,10 @@ jobs:
         password: ${{ secrets.QUAY_TOKEN }}
         registry: quay.io
 
+    - name: Align go.mod and go.sum dependencies for released components
+      run: |
+        make modules
+
     - name: Image Build and Push
       run: |
         make build

--- a/Makefile
+++ b/Makefile
@@ -158,7 +158,7 @@ modules: ## Update Go dependencies.
 	go mod tidy
 
 .PHONY: build
-build: modules fmt vet ## Build manager binary.
+build: fmt vet ## Build manager binary.
 	go build \
 		-ldflags " \
 			-X 'main.OperatorVersion=$(BUILD_VERSION)' \
@@ -169,7 +169,7 @@ build: modules fmt vet ## Build manager binary.
 		-o bin/manager main.go
 
 .PHONY: run
-run: modules manifests fmt vet ## Run a controller from your host.
+run: manifests fmt vet ## Run a controller from your host.
 	go run ./main.go
 
 .PHONY: image-build


### PR DESCRIPTION
# Issue link
<!-- insert a link to the GitHub issue -->
<!-- If the issue is closed with this PR enter 'Closes #<issue_number>' -->
N/A

# What changes have been made
<!-- describe a summary of the change, add any additional motivation and context as needed -->
Remove alignment of go.mod dependencies from image build. Now the alignment will be done only for operator release.
Current behavior broke dev image build - https://github.com/project-codeflare/codeflare-operator/actions/workflows/operator-image.yml

# Verification steps
<!-- Add thorough verification steps with sufficient level of detail for those without context to verify the change-->
<!-- AND Add thorough upgrade verification steps OR include a reason as to why it is not required -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->
Run `make build`.

## Checks
- [x] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [x] Manual tests
   - [ ] Testing is not required for this change

<!-- You can find out information on the review process at this link https://github.com/project-codeflare/codeflare/blob/develop/CONTRIBUTING.md#getting-feedback-on-your-contribution -->