### PR TITLE
update: change CSV alm-examples to ''

### DIFF
--- a/config/manifests/bases/codeflare-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/codeflare-operator.clusterserviceversion.yaml
@@ -2,7 +2,7 @@ apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
 metadata:
   annotations:
-    alm-examples: '[]'
+    alm-examples: ''
     capabilities: Basic Install
     categories: AI/Machine Learning, Big Data
     operatorframework.io/suggested-namespace: openshift-operators


### PR DESCRIPTION
# What changes have been made
During release, the community-operators-prod sync is failing [with](https://github.com/project-codeflare/codeflare-operator/blob/main/config/manifests/bases/codeflare-operator.clusterserviceversion.yaml#L5):
```
[static-tests : run-suite]     {
[static-tests : run-suite]       "type": "error",
[static-tests : run-suite]       "message": "CSV contains an invalid value for metadata.annotations.alm-examples",
[static-tests : run-suite]       "check": "check_required_fields"
[static-tests : run-suite]     },
```

this is due to the following [check](https://github.com/redhat-openshift-ecosystem/operator-pipelines/blob/main/operator-pipeline-images/operatorcert/static_tests/community/bundle.py#L184C36-L184C44):
```
        ("metadata.annotations.alm-examples", re.compile(r".{30,}", re.DOTALL), True),
```

A resolution is to set alm-examples to ''


# Verification steps
<!-- Add thorough verification steps with sufficient level of detail for those without context to verify the change-->
<!-- AND Add thorough upgrade verification steps OR include a reason as to why it is not required -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->

## Checks
- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] Testing is not required for this change

<!-- You can find out information on the review process at this link https://github.com/project-codeflare/codeflare/blob/develop/CONTRIBUTING.md#getting-feedback-on-your-contribution -->