### PR TITLE
update: change CSV alm-examples

### DIFF
--- a/config/manifests/bases/codeflare-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/codeflare-operator.clusterserviceversion.yaml
@@ -2,7 +2,45 @@ apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
 metadata:
   annotations:
-    alm-examples: '[]'
+    alm-examples: |-
+      [{
+        "apiVersion": "workload.codeflare.dev/v1beta1",
+        "kind": "AppWrapper",
+        "metadata": {"name": "0001-aw-generic-deployment-1"},
+        "spec": {
+          "resources": {
+            "GenericItems": [{
+              "replicas": 1,
+              "generictemplate": {
+                "apiVersion": "apps/v1",
+                "kind": "Deployment",
+                "metadata": {
+                  "name": "0001-aw-generic-deployment-1",
+                  "labels": {"app": "0001-aw-generic-deployment-1"}
+                },
+                "spec": {
+                  "selector": {"matchLabels": {"app": "0001-aw-generic-deployment-1"}},
+                  "replicas": 2,
+                  "template": {
+                    "metadata": {"labels": {"app": "0001-aw-generic-deployment-1"}},
+                    "spec": {
+                      "containers": [{
+                        "name": "0001-aw-generic-deployment-1",
+                        "image": "kicbase/echo-server:1.0",
+                        "ports": [{"containerPort": 80}],
+                        "resources": {
+                          "requests": {"cpu": "100m", "memory": "256Mi"},
+                          "limits": {"cpu": "100m", "memory": "256Mi"}
+                        }
+                      }]
+                    }
+                  }
+                }
+              }
+            }]
+          }
+        }
+      }]
     capabilities: Basic Install
     categories: AI/Machine Learning, Big Data
     operatorframework.io/suggested-namespace: openshift-operators


### PR DESCRIPTION
# What changes have been made
During release, the community-operators-prod sync is failing [with](https://github.com/project-codeflare/codeflare-operator/blob/main/config/manifests/bases/codeflare-operator.clusterserviceversion.yaml#L5):
```
[static-tests : run-suite]     {
[static-tests : run-suite]       "type": "error",
[static-tests : run-suite]       "message": "CSV contains an invalid value for metadata.annotations.alm-examples",
[static-tests : run-suite]       "check": "check_required_fields"
[static-tests : run-suite]     },
```

this is due to the following [check](https://github.com/redhat-openshift-ecosystem/operator-pipelines/blob/main/operator-pipeline-images/operatorcert/static_tests/community/bundle.py#L184C36-L184C44):
```
        ("metadata.annotations.alm-examples", re.compile(r".{30,}", re.DOTALL), True),
```

A resolution is to add an alm-examples for the AppWrapper CRD

## Checks
- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] Testing is not required for this change

<!-- You can find out information on the review process at this link https://github.com/project-codeflare/codeflare/blob/develop/CONTRIBUTING.md#getting-feedback-on-your-contribution -->