### PR TITLE
Instascale E2E test for nodepools

### DIFF
--- a/test/e2e/instascale_app_wrapper.go
+++ b/test/e2e/instascale_app_wrapper.go
@@ -48,6 +48,7 @@ func instaScaleJobAppWrapper(test Test, namespace *corev1.Namespace, config *cor
 							Image: GetPyTorchImage(),
 							Env: []corev1.EnvVar{
 								{Name: "PYTHONUSERBASE", Value: "/workdir"},
+								{Name: "MNIST_DATASET_URL", Value: GetMnistDatasetURL()},
 							},
 							Command: []string{"/bin/sh", "-c", "pip install -r /test/requirements.txt && torchrun /test/mnist.py"},
 							Args:    []string{"$PYTHONUSERBASE"},

--- a/test/e2e/instascale_nodepool_test.go
+++ b/test/e2e/instascale_nodepool_test.go
@@ -1,0 +1,66 @@
+package e2e
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	. "github.com/project-codeflare/codeflare-common/support"
+	mcadv1beta1 "github.com/project-codeflare/multi-cluster-app-dispatcher/pkg/apis/controller/v1beta1"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestInstascaleNodepool(t *testing.T) {
+
+	test := With(t)
+	test.T().Parallel()
+
+	clusterType := GetClusterType(test)
+	if clusterType != HypershiftCluster {
+		test.T().Skipf("Skipping test as not running on an Hypershift cluster, resolved cluster type: %s", clusterType)
+	}
+
+	namespace := test.NewTestNamespace()
+
+	// Test configuration
+	cm := CreateConfigMap(test, namespace.Name, map[string][]byte{
+		// pip requirements
+		"requirements.txt": ReadFile(test, "mnist_pip_requirements.txt"),
+		// MNIST training script
+		"mnist.py": ReadFile(test, "mnist.py"),
+	})
+
+	//create OCM connection
+	connection := CreateOCMConnection(test)
+	defer connection.Close()
+
+	// check existing cluster resources
+	// look for a node pool with a label key equal to aw name - expect NOT to find it
+	test.Expect(GetNodePools(test, connection)).
+		ShouldNot(ContainElement(WithTransform(NodePoolLabels, HaveKey(HavePrefix("test-instascale")))))
+
+	// Setup batch job and AppWrapper
+	aw := instaScaleJobAppWrapper(test, namespace, cm)
+
+	// apply AppWrapper to cluster
+	_, err := test.Client().MCAD().WorkloadV1beta1().AppWrappers(namespace.Name).Create(test.Ctx(), aw, metav1.CreateOptions{})
+	test.Expect(err).NotTo(HaveOccurred())
+	test.T().Logf("AppWrapper created successfully %s/%s", aw.Namespace, aw.Name)
+
+	// assert that AppWrapper goes to "Running" state
+	test.Eventually(AppWrapper(test, namespace, aw.Name), TestTimeoutGpuProvisioning).
+		Should(WithTransform(AppWrapperState, Equal(mcadv1beta1.AppWrapperStateActive)))
+
+	// look for a node pool with a label key equal to aw name - expect to find it
+	test.Eventually(NodePools(test, connection), TestTimeoutLong).
+		Should(ContainElement(WithTransform(NodePoolLabels, HaveKey(HavePrefix("test-instascale")))))
+
+	// assert that the AppWrapper goes to "Completed" state
+	test.Eventually(AppWrapper(test, namespace, aw.Name), TestTimeoutLong).
+		Should(WithTransform(AppWrapperState, Equal(mcadv1beta1.AppWrapperStateCompleted)))
+
+	// look for a node pool with a label key equal to aw name - expect NOT to find it
+	test.Eventually(NodePools(test, connection), TestTimeoutLong).
+		ShouldNot(ContainElement(WithTransform(NodePoolLabels, HaveKey(HavePrefix("test-instascale")))))
+
+}


### PR DESCRIPTION
# Issue link
[Jira Issue](https://issues.redhat.com/browse/RHOAIENG-1312)

# What changes have been made
An e2e test has been added to test the entire instascale flow on a ROSA Hosted Hypershift Cluster.

I have also included an update to the `instaScaleJobAppWrapper` function based on recent changes to the mnist.py script and other e2e tests.

# Verification steps
 - Provision a [Hypershift Cluster](https://docs.google.com/document/d/1x1GM7NoR5x53ESTZ-nKZa2o8MOmBVSWo5ndR0oVKPuI/edit#heading=h.aqaecxvsy88r)
 -  Install RHODS via Operator Hub setting the CodeFlare stack to `Managed`
 - Create a separate Instascale deployment using the current main branch to include recent updates regarding naming convention. 
     - Make sure to add the `instascale-ocm-secret` in the default namespace.
 -  Install NFD operator with NodeFeatureDiscovery CR.
 - Install NVIDIA operator with ClusterPolicy CR.
 - Run/debug the test and confirm that it passes.

## Checks
- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [X] Manual tests
   - [ ] Testing is not required for this change

<!-- You can find out information on the review process at this link https://github.com/project-codeflare/codeflare/blob/develop/CONTRIBUTING.md#getting-feedback-on-your-contribution -->