### PR TITLE
Add Host to Container port mapping for KinD Cluster

### DIFF
--- a/test/e2e/kind.sh
+++ b/test/e2e/kind.sh
@@ -24,6 +24,10 @@ apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
   - role: control-plane
     image: kindest/node:v1.25.3@sha256:f52781bc0d7a19fb6c405c2af83abfeb311f130707a0e219175677e366cc45d1
+    extraPortMappings:
+    - containerPort: 80
+      hostPort: 80
+      protocol: TCP
     kubeadmConfigPatches:
       - |
         kind: InitConfiguration


### PR DESCRIPTION
# Issue link
<!-- insert a link to the GitHub issue -->
<!-- If the issue is closed with this PR enter 'Closes #<issue_number>' -->
Related to: https://issues.redhat.com/browse/RHOAIENG-2058 

# What changes have been made
<!-- describe a summary of the change, add any additional motivation and context as needed -->
Map Host Port 80 to Container Port 80 in KinD Setup. Required for usage against CodeFlare-SDK e2e test.

# Verification steps
<!-- Add thorough verification steps with sufficient level of detail for those without context to verify the change-->
<!-- AND Add thorough upgrade verification steps OR include a reason as to why it is not required -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->
e2e tests should continue to pass.

## Checks
- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] Testing is not required for this change

<!-- You can find out information on the review process at this link https://github.com/project-codeflare/codeflare/blob/develop/CONTRIBUTING.md#getting-feedback-on-your-contribution -->