### PR TITLE
Raise KinD Ingress controller version to v1.9.6 for manual setup

### DIFF
--- a/test/e2e/kind.sh
+++ b/test/e2e/kind.sh
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 set -euo pipefail
-: "${INGRESS_NGINX_VERSION:=controller-v1.6.4}"
+: "${INGRESS_NGINX_VERSION:=controller-v1.9.6}"
 
 echo "Creating KinD cluster"
 cat <<EOF | kind create cluster --config=-


### PR DESCRIPTION
# Issue link
<!-- insert a link to the GitHub issue -->
<!-- If the issue is closed with this PR enter 'Closes #<issue_number>' -->
N/A

# What changes have been made
<!-- describe a summary of the change, add any additional motivation and context as needed -->
Cherrypicking https://github.com/project-codeflare/codeflare-common/pull/31 to apply change for manual KinD provision for manual tests.

# Verification steps
<!-- Add thorough verification steps with sufficient level of detail for those without context to verify the change-->
<!-- AND Add thorough upgrade verification steps OR include a reason as to why it is not required -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->
Run `make kind-e2e` and check that Ingress is properly deployed.

## Checks
- [x] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [x] Manual tests
   - [ ] Testing is not required for this change

<!-- You can find out information on the review process at this link https://github.com/project-codeflare/codeflare/blob/develop/CONTRIBUTING.md#getting-feedback-on-your-contribution -->