### PR TITLE
Fix e2e test - invalid go version error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -267,7 +267,7 @@ $(YQ): $(LOCALBIN)
 .PHONY: envtest
 envtest: $(ENVTEST) ## Download envtest-setup locally if necessary.
 $(ENVTEST): $(LOCALBIN)
-	test -s $(LOCALBIN)/setup-envtest || GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
+	test -s $(LOCALBIN)/setup-envtest || GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@release-0.17
 
 .PHONY: openshift-goimports
 openshift-goimports: $(OPENSHIFT-GOIMPORTS) ## Download openshift-goimports locally if necessary.


### PR DESCRIPTION
# Issue link
<!-- insert a link to the GitHub issue -->
<!-- If the issue is closed with this PR enter 'Closes #<issue_number>' -->
Issue: https://issues.redhat.com/browse/RHOAIENG-4765 

TLDR:
> go: sigs.k8s.io/controller-runtime/tools/setup-envtest@latest (in sigs.k8s.io/controller-runtime/tools/setup-envtest@v0.0.0-20240322145600-aeef2b60d6f7): go.mod:3: invalid go version '1.22.0': must match format 1.23


# What changes have been made
<!-- describe a summary of the change, add any additional motivation and context as needed -->
This PR provided ideas for the fix: https://github.com/KusionStack/operating/pull/169 

We are currently using the `latest` version of the mentioned dependency. 
This PR is setting it to the latest release that works with our current go version `1.20` until we can upgrade to `go1.22`

# Verification steps
<!-- Add thorough verification steps with sufficient level of detail for those without context to verify the change-->
<!-- AND Add thorough upgrade verification steps OR include a reason as to why it is not required -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->
- e2e tests should pass on this PR.

## Checks
- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] Testing is not required for this change

<!-- You can find out information on the review process at this link https://github.com/project-codeflare/codeflare/blob/develop/CONTRIBUTING.md#getting-feedback-on-your-contribution -->