### PR TITLE
RC Controller - Avoid multiple calls to DiscoveryAPI

### DIFF
--- a/main.go
+++ b/main.go
@@ -146,9 +146,9 @@ func main() {
 	})
 	exitOnError(err, "unable to start manager")
 
-	v, err := HasAPIResourceForGVK(kubeClient.DiscoveryClient, rayv1.GroupVersion.WithKind("RayCluster"))
-	if v {
-		rayClusterController := controllers.RayClusterReconciler{Client: mgr.GetClient(), Scheme: mgr.GetScheme(), Config: cfg}
+	ok, err := HasAPIResourceForGVK(kubeClient.DiscoveryClient, rayv1.GroupVersion.WithKind("RayCluster"))
+	if ok {
+		rayClusterController := controllers.RayClusterReconciler{Client: mgr.GetClient(), Scheme: mgr.GetScheme(), Config: cfg.KubeRay}
 		exitOnError(rayClusterController.SetupWithManager(mgr), "Error setting up RayCluster controller")
 	} else if err != nil {
 		exitOnError(err, "Could not determine if RayCluster CR present on cluster.")

--- a/pkg/controllers/raycluster_controller.go
+++ b/pkg/controllers/raycluster_controller.go
@@ -187,7 +187,7 @@ func (r *RayClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		}
 
 	} else if cluster.Status.State != "suspended" && !r.isRayDashboardOAuthEnabled() && !r.IsOpenShift {
-		ingressDomain := ""
+		ingressDomain := "" // TODO: ingressDomain should be retrieved by the CFO and used here to fix local_interactive. Jira: https://issues.redhat.com/browse/RHOAIENG-5330
 		logger.Info("Creating Dashboard Ingress")
 		_, err := r.kubeClient.NetworkingV1().Ingresses(cluster.Namespace).Apply(ctx, desiredClusterIngress(&cluster, getIngressHost(ctx, r.kubeClient, &cluster, ingressDomain)), metav1.ApplyOptions{FieldManager: controllerName, Force: true})
 		if err != nil {


### PR DESCRIPTION
# Issue link
<!-- insert a link to the GitHub issue -->
<!-- If the issue is closed with this PR enter 'Closes #<issue_number>' -->
Jira: https://issues.redhat.com/browse/RHOAIENG-5333 

# What changes have been made
<!-- describe a summary of the change, add any additional motivation and context as needed -->
- In the support file, we are separating concerns between what is needed for OpenShift and KinD clusters. I.e., `ingressHost` is only required for ingresses.
- Added `isOpenShiftInitalized` variable - Its purpose is to ensure that when checking if the cluster type is `OpenShift`, this check and call to the DiscoveryAPI is only performed once.
- Accessing KubeRay configuration directly.

# Verification steps
<!-- Add thorough verification steps with sufficient level of detail for those without context to verify the change-->
<!-- AND Add thorough upgrade verification steps OR include a reason as to why it is not required -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->

**Overall functionality remains the same.**

**On OpenShift:**
1. Login to your OpenShift cluster.
2. Run KubeRay v1.1.0 - [Install doc](https://docs.ray.io/en/master/cluster/kubernetes/getting-started/raycluster-quick-start.html#:~:text=kindest/node%3Av1.26.0-,Step%202%3A%20Deploy%20a%20KubeRay%20operator,-%23)
3. Run the CFO locally against the cluster with `make run NAMESPACE=somenamespace`
4. Run Kueue: deploy Kueue with `kubectl apply --server-side -k "github.com/opendatahub-io/kueue/config/rhoai?ref=dev"`
5. Create `ClusterQueue`, `LocalQueue`, and `ResourceFlavor` if not done already.
6. Install the latest SDK from main branch.
7. Attempt to create a RayCluster in a notebook with:
```
cluster = Cluster(ClusterConfiguration(
    name='jobtest',
    namespace='default', # or localqueue namespace
    num_workers=1,
    min_cpus=1,
    max_cpus=1,
    min_memory=2,
    max_memory=2,
    num_gpus=0,
    write_to_file=True,
    image="quay.io/project-codeflare/ray:latest-py39-cu118"
))
```
8. RayCluster pods should be created, and the RayCluster controller in the CFO should successfully create an accessible dashboard route.

**On KinD:**
Same steps as for OpenShift, except we shall [turn OAuth to `false`](https://github.com/project-codeflare/codeflare-operator/blob/main/main.go#L117) to enable RC Controller to create ingresses instead.



## Checks
- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] Testing is not required for this change

<!-- You can find out information on the review process at this link https://github.com/project-codeflare/codeflare/blob/develop/CONTRIBUTING.md#getting-feedback-on-your-contribution -->