### PR TITLE
Exit CFO initialisation if RayCluster CRD is not available

### DIFF
--- a/.github/workflows/olm_tests.yaml
+++ b/.github/workflows/olm_tests.yaml
@@ -72,6 +72,13 @@ jobs:
           kubectl create namespace openshift-operators
           kubectl create -f .github/resources-olm-upgrade/operatorgroup.yaml
 
+      - name: Install Required KubeRay CRDs for Pod Initialisation
+        run: |
+          kubectl create -f https://raw.githubusercontent.com/ray-project/kuberay/v1.1.0/ray-operator/config/crd/bases/ray.io_rayclusters.yaml
+          # wait for a while to be sure CRDs are installed
+          sleep 1
+          kubectl wait --for=condition=Established crd/rayclusters.ray.io --timeout=60s
+
       - name: Deploy latest released CodeFlare operator from OLM
         id: deploy
         run: |


### PR DESCRIPTION
# Issue link
<!-- insert a link to the GitHub issue -->
<!-- If the issue is closed with this PR enter 'Closes #<issue_number>' -->
Jira: https://issues.redhat.com/browse/RHOAIENG-5331 

# What changes have been made
<!-- describe a summary of the change, add any additional motivation and context as needed -->
- Refactored to exit early if the RayCluster CRD is not present in the cluster.

Note: This could be considered a temporary change until the RC Controller is moved to KubeRay.

# Verification steps
<!-- Add thorough verification steps with sufficient level of detail for those without context to verify the change-->
<!-- AND Add thorough upgrade verification steps OR include a reason as to why it is not required -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->

1. Deploy the CFO without KubeRay and Ray CRDs:
```
podman build -t quay.io/<quayusername>/codeflare-operator:<tagname> .
podman push quay.io/<quayusername>/codeflare-operator:<tagname>
make deploy IMG=quay.io/<quayusername>/codeflare-operator:<tagname>
```
2. The CFO pod will fail to initialise and will restart the pod until the required CRDs are available in the cluster. Deploying KubeRay installs the required CRDs and the CFO pod should start.


## Checks
- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] Testing is not required for this change

<!-- You can find out information on the review process at this link https://github.com/project-codeflare/codeflare/blob/develop/CONTRIBUTING.md#getting-feedback-on-your-contribution -->