### PR TITLE
Fix and enable local_interactive feature by default

### DIFF
--- a/config/e2e/config.yaml
+++ b/config/e2e/config.yaml
@@ -6,3 +6,4 @@ data:
   config.yaml: |
     kuberay:
       rayDashboardOAuthEnabled: false
+      ingressDomain: "kind"

--- a/main.go
+++ b/main.go
@@ -115,6 +115,7 @@ func main() {
 		},
 		KubeRay: &config.KubeRayConfiguration{
 			RayDashboardOAuthEnabled: pointer.Bool(true),
+			IngressDomain:            "fake.domain",
 		},
 	}
 

--- a/main.go
+++ b/main.go
@@ -115,7 +115,7 @@ func main() {
 		},
 		KubeRay: &config.KubeRayConfiguration{
 			RayDashboardOAuthEnabled: pointer.Bool(true),
-			IngressDomain:            "fake.domain",
+			IngressDomain:            "",
 		},
 	}
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -34,7 +34,7 @@ type CodeFlareOperatorConfiguration struct {
 type KubeRayConfiguration struct {
 	RayDashboardOAuthEnabled *bool `json:"rayDashboardOAuthEnabled,omitempty"`
 
-	IngressDomain string `json:"ingressDomain,omitempty"`
+	IngressDomain string `json:"ingressDomain"`
 }
 
 type ControllerManager struct {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -33,6 +33,8 @@ type CodeFlareOperatorConfiguration struct {
 
 type KubeRayConfiguration struct {
 	RayDashboardOAuthEnabled *bool `json:"rayDashboardOAuthEnabled,omitempty"`
+
+	IngressDomain string `json:"ingressDomain,omitempty"`
 }
 
 type ControllerManager struct {

--- a/pkg/controllers/raycluster_controller.go
+++ b/pkg/controllers/raycluster_controller.go
@@ -187,7 +187,11 @@ func (r *RayClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		logger.Info("We detected being on Vanilla Kubernetes!")
 		logger.Info("Creating Dashboard Ingress")
 		dashboardName := dashboardNameFromCluster(&cluster)
-		_, err := r.kubeClient.NetworkingV1().Ingresses(cluster.Namespace).Apply(ctx, desiredClusterIngress(&cluster, r.getIngressHost(ctx, r.kubeClient, &cluster, dashboardName)), metav1.ApplyOptions{FieldManager: controllerName, Force: true})
+		dashboardIngressHost, err := r.getIngressHost(ctx, r.kubeClient, &cluster, dashboardName)
+		if err != nil {
+			return ctrl.Result{RequeueAfter: requeueTime}, err
+		}
+		_, err = r.kubeClient.NetworkingV1().Ingresses(cluster.Namespace).Apply(ctx, desiredClusterIngress(&cluster, dashboardIngressHost), metav1.ApplyOptions{FieldManager: controllerName, Force: true})
 		if err != nil {
 			// This log is info level since errors are not fatal and are expected
 			logger.Info("WARN: Failed to update Dashboard Ingress", "error", err.Error(), logRequeueing, true)
@@ -195,7 +199,11 @@ func (r *RayClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		}
 		logger.Info("Creating RayClient Ingress")
 		rayClientName := rayClientNameFromCluster(&cluster)
-		_, err = r.kubeClient.NetworkingV1().Ingresses(cluster.Namespace).Apply(ctx, desiredRayClientIngress(&cluster, r.getIngressHost(ctx, r.kubeClient, &cluster, rayClientName)), metav1.ApplyOptions{FieldManager: controllerName, Force: true})
+		rayClientIngressHost, err := r.getIngressHost(ctx, r.kubeClient, &cluster, rayClientName)
+		if err != nil {
+			return ctrl.Result{RequeueAfter: requeueTime}, err
+		}
+		_, err = r.kubeClient.NetworkingV1().Ingresses(cluster.Namespace).Apply(ctx, desiredRayClientIngress(&cluster, rayClientIngressHost), metav1.ApplyOptions{FieldManager: controllerName, Force: true})
 		if err != nil {
 			logger.Error(err, "Failed to update RayClient Ingress")
 			return ctrl.Result{RequeueAfter: requeueTime}, err

--- a/pkg/controllers/support.go
+++ b/pkg/controllers/support.go
@@ -139,15 +139,17 @@ func isOpenShift(ctx context.Context, clientset *kubernetes.Clientset, cluster *
 }
 
 // getIngressHost generates the cluster URL string based on the cluster type, RayCluster, and ingress domain.
-func (r *RayClusterReconciler) getIngressHost(ctx context.Context, clientset *kubernetes.Clientset, cluster *rayv1.RayCluster, ingressNameFromCluster string) string {
-	ingressDomain := "fake.domain"
+func (r *RayClusterReconciler) getIngressHost(ctx context.Context, clientset *kubernetes.Clientset, cluster *rayv1.RayCluster, ingressNameFromCluster string) (string, error) {
+	ingressDomain := ""
 	if r.Config != nil && r.Config.IngressDomain != "" {
 		ingressDomain = r.Config.IngressDomain
+	} else {
+		return "", fmt.Errorf("missing IngressDomain configuration in ConfigMap 'codeflare-operator-config'")
 	}
 	if ingressDomain == "kind" {
-		return ingressDomain
+		return ingressDomain, nil
 	}
-	return fmt.Sprintf("%s-%s.%s", ingressNameFromCluster, cluster.Namespace, ingressDomain)
+	return fmt.Sprintf("%s-%s.%s", ingressNameFromCluster, cluster.Namespace, ingressDomain), nil
 }
 
 func (r *RayClusterReconciler) isRayDashboardOAuthEnabled() bool {

--- a/pkg/controllers/support.go
+++ b/pkg/controllers/support.go
@@ -3,7 +3,6 @@ package controllers
 import (
 	"context"
 	"fmt"
-	"strconv"
 	"strings"
 
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
@@ -30,7 +29,6 @@ func desiredRayClientRoute(cluster *rayv1.RayCluster) *routeapply.RouteApplyConf
 	return routeapply.Route(rayClientNameFromCluster(cluster), cluster.Namespace).
 		WithLabels(map[string]string{"ray.io/cluster-name": cluster.Name}).
 		WithSpec(routeapply.RouteSpec().
-			WithHost(rayClientNameFromCluster(cluster) + "-" + cluster.Namespace).
 			WithTo(routeapply.RouteTargetReference().WithKind("Service").WithName(serviceNameFromCluster(cluster)).WithWeight(100)).
 			WithPort(routeapply.RoutePort().WithTargetPort(intstr.FromString("client"))).
 			WithTLS(routeapply.TLSConfig().WithTermination("passthrough")),
@@ -171,18 +169,4 @@ func (r *RayClusterReconciler) isRayDashboardOAuthEnabled() bool {
 		return *r.Config.RayDashboardOAuthEnabled
 	}
 	return true
-}
-
-func annotationBoolVal(ctx context.Context, cluster *rayv1.RayCluster, annotation string, defaultValue bool) bool {
-	logger := ctrl.LoggerFrom(ctx)
-	val, exists := cluster.ObjectMeta.Annotations[annotation]
-	if !exists || val == "" {
-		return defaultValue
-	}
-	boolVal, err := strconv.ParseBool(val)
-	if err != nil {
-		logger.Error(err, "Could not convert annotation value to bool", "annotation", annotation, "value", val)
-		return defaultValue
-	}
-	return boolVal
 }


### PR DESCRIPTION
Rayclient Route to resolve its own ingress domain, and enable local_interactive by default

# Issue link
<!-- insert a link to the GitHub issue -->
<!-- If the issue is closed with this PR enter 'Closes #<issue_number>' -->
Jira: https://issues.redhat.com/browse/RHOAIENG-5330 

# What changes have been made
<!-- describe a summary of the change, add any additional motivation and context as needed -->
- Set local_interactive feature to be always enabled by default.
- RayClient Route now resolves its own `ingress domain` based on the route's name and namespace.
- Removed unused `annotationBoolVal()`
- Add `ingressDomain` field to CFO configmap: This field has `fake.domain` set as default and is used for the generation of the full rayclient client and dashboard ingress hosts. I.e., `ray-dashboard-<clusterName>-<namespace>.fake.domain` or `rayclient-<clusterName>-<namespace>.fake.domain`. For the e2e workflow, the ingressDomain is set to "kind".

# Verification steps
<!-- Add thorough verification steps with sufficient level of detail for those without context to verify the change-->
<!-- AND Add thorough upgrade verification steps OR include a reason as to why it is not required -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->

## Checks
- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] Testing is not required for this change

<!-- You can find out information on the review process at this link https://github.com/project-codeflare/codeflare/blob/develop/CONTRIBUTING.md#getting-feedback-on-your-contribution -->