### PR TITLE
Add a ConfigMap for e2e tests

### DIFF
--- a/.github/workflows/e2e_tests.yaml
+++ b/.github/workflows/e2e_tests.yaml
@@ -60,7 +60,6 @@ jobs:
         run: |
           echo Deploying CodeFlare operator
           IMG="${REGISTRY_ADDRESS}"/codeflare-operator
-          sed -i 's/RayDashboardOAuthEnabled: pointer.Bool(true)/RayDashboardOAuthEnabled: pointer.Bool(false)/' main.go
           make image-push -e IMG="${IMG}"
           make deploy -e IMG="${IMG}" -e ENV="e2e"
           kubectl wait --timeout=120s --for=condition=Available=true deployment -n openshift-operators codeflare-operator-manager

--- a/config/e2e/config.yaml
+++ b/config/e2e/config.yaml
@@ -1,0 +1,8 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: codeflare-operator-config
+data:
+  config.yaml: |
+    kuberay:
+      rayDashboardOAuthEnabled: false

--- a/config/e2e/kustomization.yaml
+++ b/config/e2e/kustomization.yaml
@@ -1,6 +1,7 @@
 namespace: openshift-operators
 
 bases:
+- config.yaml
 - ../default
 
 patches:


### PR DESCRIPTION
This (re-)adds the ConfigMap used for e2e tests, instead of monkey patching the operator code.