### PR TITLE
Use Dnsmasq to provide DNS for KinD

### DIFF
--- a/pkg/controllers/support.go
+++ b/pkg/controllers/support.go
@@ -146,9 +146,6 @@ func (r *RayClusterReconciler) getIngressHost(ctx context.Context, clientset *ku
 	} else {
 		return "", fmt.Errorf("missing IngressDomain configuration in ConfigMap 'codeflare-operator-config'")
 	}
-	if ingressDomain == "kind" {
-		return ingressDomain, nil
-	}
 	return fmt.Sprintf("%s-%s.%s", ingressNameFromCluster, cluster.Namespace, ingressDomain), nil
 }
 


### PR DESCRIPTION
# Issue link
<!-- insert a link to the GitHub issue -->
<!-- If the issue is closed with this PR enter 'Closes #<issue_number>' -->
N/A

# What changes have been made
<!-- describe a summary of the change, add any additional motivation and context as needed -->
Adjusted existing e2e test to use Ingress/Route created by operator to download job logs.
Currently the test doesn't work on OpenShift because oauth container is still created by SDK. Once oauth creation is part of operator then it should work on OpenShift.

# Verification steps
<!-- Add thorough verification steps with sufficient level of detail for those without context to verify the change-->
<!-- AND Add thorough upgrade verification steps OR include a reason as to why it is not required -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->
Verified by running PR check. Manual verification limited due to OpenShift issues.
Can be verified by running e2e test against fully deployed KinD cluster with Kuberay and operator.

## Checks
- [x] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [x] Manual tests
   - [ ] Testing is not required for this change

<!-- You can find out information on the review process at this link https://github.com/project-codeflare/codeflare/blob/develop/CONTRIBUTING.md#getting-feedback-on-your-contribution -->