### PR TITLE
fix(manifests): missing namespace in CM stack-config

### DIFF
--- a/config/manager/params.env
+++ b/config/manager/params.env
@@ -1,1 +1,2 @@
 codeflare-operator-controller-image=quay.io/opendatahub/codeflare-operator:v1.3.1
+namespace=opendatahub


### PR DESCRIPTION
# Issue link
<!-- insert a link to the GitHub issue -->
<!-- If the issue is closed with this PR enter 'Closes #<issue_number>' -->
introduced in change https://github.com/opendatahub-io/codeflare-operator/commit/afe5bdc7fb34bddc72bbc8e177d31eaa9fb32bde
cause error:
`* field specified in var '{namespace ConfigMap.v1.[noGrp] {data.namespace}}' not found in corresponding resource`
which prevent deployment in ODH operator


# What changes have been made
<!-- describe a summary of the change, add any additional motivation and context as needed -->

# Verification steps
<!-- Add thorough verification steps with sufficient level of detail for those without context to verify the change-->
<!-- AND Add thorough upgrade verification steps OR include a reason as to why it is not required -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->

## Checks
- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] Testing is not required for this change

<!-- You can find out information on the review process at this link https://github.com/project-codeflare/codeflare/blob/develop/CONTRIBUTING.md#getting-feedback-on-your-contribution -->