### PR TITLE
Get go version for setup-go action from go.mod file

### DIFF
--- a/.github/workflows/component_tests.yaml
+++ b/.github/workflows/component_tests.yaml
@@ -36,7 +36,7 @@ jobs:
       - name: Set Go
         uses: actions/setup-go@v5
         with:
-          go-version: v1.20
+          go-version-file: './go.mod'
 
       - name: Run component tests
         run: |

--- a/.github/workflows/e2e_tests.yaml
+++ b/.github/workflows/e2e_tests.yaml
@@ -45,7 +45,7 @@ jobs:
       - name: Set Go
         uses: actions/setup-go@v5
         with:
-          go-version: v1.20
+          go-version-file: './go.mod'
 
       - name: Set up gotestfmt
         uses: gotesttools/gotestfmt-action@v2

--- a/.github/workflows/mnist-job-test-image.yml
+++ b/.github/workflows/mnist-job-test-image.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Set Go
       uses: actions/setup-go@v5
       with:
-        go-version: v1.20
+        go-version-file: './go.mod'
 
     - name: Login to Quay.io
       id: podman-login-quay

--- a/.github/workflows/olm_tests.yaml
+++ b/.github/workflows/olm_tests.yaml
@@ -44,7 +44,7 @@ jobs:
       - name: Set Go
         uses: actions/setup-go@v5
         with:
-          go-version: v1.20
+          go-version-file: './go.mod'
 
       - name: Set up gotestfmt
         uses: gotesttools/gotestfmt-action@v2

--- a/.github/workflows/operator-image.yml
+++ b/.github/workflows/operator-image.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Set Go
       uses: actions/setup-go@v5
       with:
-        go-version: v1.20
+        go-version-file: './go.mod'
 
     - name: Login to Quay.io
       id: podman-login-quay

--- a/.github/workflows/precommit.yml
+++ b/.github/workflows/precommit.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Set Go
         uses: actions/setup-go@v5
         with:
-          go-version: v1.20
+          go-version-file: './go.mod'
 
       - name: Activate cache
         uses: actions/cache@v4

--- a/.github/workflows/tag-and-build.yml
+++ b/.github/workflows/tag-and-build.yml
@@ -56,7 +56,7 @@ jobs:
     - name: Set Go
       uses: actions/setup-go@v5
       with:
-        go-version: v1.20
+        go-version-file: './go.mod'
 
     - name: Verify that release doesn't exist yet
       shell: bash {0}

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Set Go
         uses: actions/setup-go@v5
         with:
-          go-version: v1.20
+          go-version-file: './go.mod'
 
       - name: Activate cache
         uses: actions/cache@v4

--- a/.github/workflows/verify_generated_files.yml
+++ b/.github/workflows/verify_generated_files.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Set Go
       uses: actions/setup-go@v5
       with:
-        go-version: v1.20
+        go-version-file: './go.mod'
     - name: Verify that imports are organized
       run: make verify-imports
 
@@ -35,6 +35,6 @@ jobs:
     - name: Set Go
       uses: actions/setup-go@v5
       with:
-        go-version: v1.20
+        go-version-file: './go.mod'
     - name: Verify that the latest WebhookConfigurations, ClusterRoles, and CustomResourceDefinitions have been generated
       run: make manifests && git diff --exit-code


### PR DESCRIPTION
This does not change the go version, but means that when we do change it in go.mod we don't have to manually change all the GitHub workflows.