### PR TITLE
Allow for custom CertGeneratorImage

### DIFF
--- a/config/e2e/config.yaml
+++ b/config/e2e/config.yaml
@@ -7,3 +7,4 @@ data:
     kuberay:
       rayDashboardOAuthEnabled: false
       ingressDomain: "kind"
+      certGeneratorImage: "quay.io/project-codeflare/ray:latest-py39-cu118"

--- a/config/e2e/config.yaml
+++ b/config/e2e/config.yaml
@@ -7,4 +7,4 @@ data:
     kuberay:
       rayDashboardOAuthEnabled: false
       ingressDomain: "kind"
-      certGeneratorImage: "quay.io/project-codeflare/ray:latest-py39-cu118"
+      mTLSEnabled: false

--- a/main.go
+++ b/main.go
@@ -129,6 +129,7 @@ func main() {
 			RayDashboardOAuthEnabled: ptr.To(true),
 			IngressDomain:            "",
 			MTLSEnabled:              ptr.To(true),
+			CertGeneratorImage:       "quay.io/project-codeflare/ray:latest-py39-cu118",
 		},
 	}
 

--- a/main.go
+++ b/main.go
@@ -129,7 +129,7 @@ func main() {
 			RayDashboardOAuthEnabled: ptr.To(true),
 			IngressDomain:            "",
 			MTLSEnabled:              ptr.To(true),
-			CertGeneratorImage:       "quay.io/project-codeflare/ray:latest-py39-cu118",
+			CertGeneratorImage:       "registry.access.redhat.com/ubi9@sha256:770cf07083e1c85ae69c25181a205b7cdef63c11b794c89b3b487d4670b4c328",
 		},
 	}
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -37,6 +37,8 @@ type KubeRayConfiguration struct {
 	IngressDomain string `json:"ingressDomain"`
 
 	MTLSEnabled *bool `json:"mTLSEnabled,omitempty"`
+
+	CertGeneratorImage string `json:"certGeneratorImage"`
 }
 
 type ControllerManager struct {

--- a/pkg/controllers/raycluster_webhook.go
+++ b/pkg/controllers/raycluster_webhook.go
@@ -87,7 +87,7 @@ func (w *rayClusterWebhook) Default(ctx context.Context, obj runtime.Object) err
 		}
 
 		// Append the create-cert Init Container
-		rayCluster.Spec.HeadGroupSpec.Template.Spec.InitContainers = upsert(rayCluster.Spec.HeadGroupSpec.Template.Spec.InitContainers, rayHeadInitContainer(rayCluster, w.Config.IngressDomain), withContainerName(initContainerName))
+		rayCluster.Spec.HeadGroupSpec.Template.Spec.InitContainers = upsert(rayCluster.Spec.HeadGroupSpec.Template.Spec.InitContainers, rayHeadInitContainer(rayCluster, w.Config.IngressDomain, w.Config.CertGeneratorImage), withContainerName(initContainerName))
 
 		// Append the CA volumes
 		for _, caVol := range caVolumes(rayCluster) {
@@ -117,7 +117,7 @@ func (w *rayClusterWebhook) Default(ctx context.Context, obj runtime.Object) err
 		}
 
 		// Append the create-cert Init Container
-		rayCluster.Spec.WorkerGroupSpecs[0].Template.Spec.InitContainers = upsert(rayCluster.Spec.WorkerGroupSpecs[0].Template.Spec.InitContainers, rayWorkerInitContainer(), withContainerName(initContainerName))
+		rayCluster.Spec.WorkerGroupSpecs[0].Template.Spec.InitContainers = upsert(rayCluster.Spec.WorkerGroupSpecs[0].Template.Spec.InitContainers, rayWorkerInitContainer(w.Config.CertGeneratorImage), withContainerName(initContainerName))
 	}
 
 	return nil
@@ -161,8 +161,8 @@ func (w *rayClusterWebhook) ValidateUpdate(ctx context.Context, oldObj, newObj r
 
 	// Init Container related errors
 	if ptr.Deref(w.Config.MTLSEnabled, true) {
-		allErrors = append(allErrors, validateHeadInitContainer(rayCluster, w.Config.IngressDomain)...)
-		allErrors = append(allErrors, validateWorkerInitContainer(rayCluster)...)
+		allErrors = append(allErrors, validateHeadInitContainer(rayCluster, w.Config.IngressDomain, w.Config.CertGeneratorImage)...)
+		allErrors = append(allErrors, validateWorkerInitContainer(rayCluster, w.Config.CertGeneratorImage)...)
 		allErrors = append(allErrors, validateHeadEnvVars(rayCluster)...)
 		allErrors = append(allErrors, validateWorkerEnvVars(rayCluster)...)
 		allErrors = append(allErrors, validateCaVolumes(rayCluster)...)
@@ -339,14 +339,14 @@ func caVolumes(rayCluster *rayv1.RayCluster) []corev1.Volume {
 	}
 }
 
-func rayHeadInitContainer(rayCluster *rayv1.RayCluster, domain string) corev1.Container {
+func rayHeadInitContainer(rayCluster *rayv1.RayCluster, domain string, certGeneratorImage string) corev1.Container {
 	rayClientRoute := "rayclient-" + rayCluster.Name + "-" + rayCluster.Namespace + "." + domain
 	// Service name for basic interactive
 	svcDomain := rayCluster.Name + "-head-svc." + rayCluster.Namespace + ".svc"
 
 	initContainerHead := corev1.Container{
 		Name:  "create-cert",
-		Image: "quay.io/project-codeflare/ray:latest-py39-cu118",
+		Image: certGeneratorImage,
 		Command: []string{
 			"sh",
 			"-c",
@@ -357,10 +357,10 @@ func rayHeadInitContainer(rayCluster *rayv1.RayCluster, domain string) corev1.Co
 	return initContainerHead
 }
 
-func rayWorkerInitContainer() corev1.Container {
+func rayWorkerInitContainer(certGeneratorImage string) corev1.Container {
 	initContainerWorker := corev1.Container{
 		Name:  "create-cert",
-		Image: "quay.io/project-codeflare/ray:latest-py39-cu118",
+		Image: certGeneratorImage,
 		Command: []string{
 			"sh",
 			"-c",
@@ -371,10 +371,10 @@ func rayWorkerInitContainer() corev1.Container {
 	return initContainerWorker
 }
 
-func validateHeadInitContainer(rayCluster *rayv1.RayCluster, domain string) field.ErrorList {
+func validateHeadInitContainer(rayCluster *rayv1.RayCluster, domain string, certGeneratorImage string) field.ErrorList {
 	var allErrors field.ErrorList
 
-	if err := contains(rayCluster.Spec.HeadGroupSpec.Template.Spec.InitContainers, rayHeadInitContainer(rayCluster, domain), byContainerName,
+	if err := contains(rayCluster.Spec.HeadGroupSpec.Template.Spec.InitContainers, rayHeadInitContainer(rayCluster, domain, certGeneratorImage), byContainerName,
 		field.NewPath("spec", "headGroupSpec", "template", "spec", "initContainers"),
 		"create-cert Init Container is immutable"); err != nil {
 		allErrors = append(allErrors, err)
@@ -383,10 +383,10 @@ func validateHeadInitContainer(rayCluster *rayv1.RayCluster, domain string) fiel
 	return allErrors
 }
 
-func validateWorkerInitContainer(rayCluster *rayv1.RayCluster) field.ErrorList {
+func validateWorkerInitContainer(rayCluster *rayv1.RayCluster, certGeneratorImage string) field.ErrorList {
 	var allErrors field.ErrorList
 
-	if err := contains(rayCluster.Spec.WorkerGroupSpecs[0].Template.Spec.InitContainers, rayWorkerInitContainer(), byContainerName,
+	if err := contains(rayCluster.Spec.WorkerGroupSpecs[0].Template.Spec.InitContainers, rayWorkerInitContainer(certGeneratorImage), byContainerName,
 		field.NewPath("spec", "workerGroupSpecs", "0", "template", "spec", "initContainers"),
 		"create-cert Init Container is immutable"); err != nil {
 		allErrors = append(allErrors, err)


### PR DESCRIPTION
# Issue link
[RHOAIENG-6505](https://issues.redhat.com/browse/RHOAIENG-6505)

# What changes have been made
I updated the CFO config to include an image to be used for cert creation in the init containers added by the CFO webhook. This is added so that in the case of a disconnected cluster there is not an extra image required.

# Verification steps
- Install CodeFlare Operator from this branch, and provide a custom image in the `codeflare-operator-config` configMap adding the image to the kuberay configuration like this:
```
    kuberay:
      ingressDomain: ""
      mTLSEnabled: true
      rayDashboardOAuthEnabled: true
      certGeneratorImage: "registry.access.redhat.com/ubi9@sha256:770cf07083e1c85ae69c25181a205b7cdef63c11b794c89b3b487d4670b4c328"
```
- Restart the CFO pod.
- Create a raycluster using a demo notebook, and check that the init containers are using the image specified in the configmap and that the raycluster pods are created succesfully. 

## Checks
- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [X] Manual tests
   - [ ] Testing is not required for this change

<!-- You can find out information on the review process at this link https://github.com/project-codeflare/codeflare/blob/develop/CONTRIBUTING.md#getting-feedback-on-your-contribution -->