### PR TITLE
Enable mTLS for e2e tests and HTTPS for KinD cluster

### DIFF
--- a/config/e2e/config.yaml
+++ b/config/e2e/config.yaml
@@ -7,6 +7,6 @@ data:
     kuberay:
       rayDashboardOAuthEnabled: false
       ingressDomain: "kind"
-      mTLSEnabled: false
+      certGeneratorImage: quay.io/project-codeflare/ray:latest-py39-cu118
     appwrapper:
       enabled: true

--- a/test/e2e/kind.sh
+++ b/test/e2e/kind.sh
@@ -28,6 +28,9 @@ nodes:
     - containerPort: 80
       hostPort: 80
       protocol: TCP
+    - containerPort: 443
+      hostPort: 443
+      protocol: TCP
     kubeadmConfigPatches:
       - |
         kind: InitConfiguration
@@ -39,4 +42,5 @@ EOF
 echo "Deploying Ingress controller into KinD cluster"
 curl https://raw.githubusercontent.com/kubernetes/ingress-nginx/"${INGRESS_NGINX_VERSION}"/deploy/static/provider/kind/deploy.yaml | sed "s/--publish-status-address=localhost/--report-node-internal-ip-address\\n        - --status-update-interval=10/g" | kubectl apply -f -
 kubectl annotate ingressclass nginx "ingressclass.kubernetes.io/is-default-class=true"
+kubectl patch deploy --type json --patch '[{"op":"add","path": "/spec/template/spec/containers/0/args/-","value":"--enable-ssl-passthrough"}]' ingress-nginx-controller -n ingress-nginx
 kubectl -n ingress-nginx wait --timeout=300s --for=condition=Available deployments --all


### PR DESCRIPTION
# Issue link
<!-- insert a link to the GitHub issue -->
<!-- If the issue is closed with this PR enter 'Closes #<issue_number>' -->
https://issues.redhat.com/browse/RHOAIENG-7055

# What changes have been made
<!-- describe a summary of the change, add any additional motivation and context as needed -->
Exposing HTTPS endpoint on KinD to be able to test gRPC calls.

# Verification steps
<!-- Add thorough verification steps with sufficient level of detail for those without context to verify the change-->
<!-- AND Add thorough upgrade verification steps OR include a reason as to why it is not required -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->
N/A

## Checks
- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] Testing is not required for this change

<!-- You can find out information on the review process at this link https://github.com/project-codeflare/codeflare/blob/develop/CONTRIBUTING.md#getting-feedback-on-your-contribution -->