### PR TITLE
CertGeneratorImage to reference registry.redhat.io

### DIFF
--- a/main.go
+++ b/main.go
@@ -142,7 +142,7 @@ func main() {
 			RayDashboardOAuthEnabled: ptr.To(true),
 			IngressDomain:            "",
 			MTLSEnabled:              ptr.To(true),
-			CertGeneratorImage:       "registry.access.redhat.com/ubi9@sha256:770cf07083e1c85ae69c25181a205b7cdef63c11b794c89b3b487d4670b4c328",
+			CertGeneratorImage:       "registry.redhat.io/ubi9@sha256:770cf07083e1c85ae69c25181a205b7cdef63c11b794c89b3b487d4670b4c328",
 		},
 		AppWrapper: &config.AppWrapperConfiguration{
 			Enabled: ptr.To(false),


### PR DESCRIPTION
# Issue link
<!-- insert a link to the GitHub issue -->
<!-- If the issue is closed with this PR enter 'Closes #<issue_number>' -->
Jira: https://issues.redhat.com/browse/RHOAIENG-8274 

# What changes have been made
<!-- describe a summary of the change, add any additional motivation and context as needed -->
- CertGeneratorImage to reference registry.redhat.io

# Verification steps
<!-- Add thorough verification steps with sufficient level of detail for those without context to verify the change-->
<!-- AND Add thorough upgrade verification steps OR include a reason as to why it is not required -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->
- If the CodeFlare-Operator was previously installed, please delete the `codeflare-operator-config` configmap before re-installing.
- Install CodeFlare-Operator from this branch
- Create a raycluster using a demo notebook, and check that the init containers are using the image specified in the configmap and that the raycluster pods are created succesfully. 

## Checks
- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] Testing is not required for this change

<!-- You can find out information on the review process at this link https://github.com/project-codeflare/codeflare/blob/develop/CONTRIBUTING.md#getting-feedback-on-your-contribution -->