### PR TITLE
Updated e2e cert generator image

### DIFF
--- a/config/e2e/config.yaml
+++ b/config/e2e/config.yaml
@@ -7,6 +7,6 @@ data:
     kuberay:
       rayDashboardOAuthEnabled: false
       ingressDomain: "kind"
-      certGeneratorImage: quay.io/project-codeflare/ray:latest-py39-cu118
+      certGeneratorImage: quay.io/project-codeflare/ray:2.20.0-py39-cu118
     appwrapper:
       enabled: true

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/openshift/api v0.0.0-20230823114715-5fdd7511b790
 	github.com/openshift/client-go v0.0.0-20221019143426-16aed247da5c
 	github.com/project-codeflare/appwrapper v0.13.0
-	github.com/project-codeflare/codeflare-common v0.0.0-20240528061920-68eadc29b5b0
+	github.com/project-codeflare/codeflare-common v0.0.0-20240617130731-0c3f3b3c0e5f
 	github.com/ray-project/kuberay/ray-operator v1.1.0
 	go.uber.org/zap v1.26.0
 	golang.org/x/exp v0.0.0-20230905200255-921286631fa9

--- a/go.sum
+++ b/go.sum
@@ -244,8 +244,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/project-codeflare/appwrapper v0.13.0 h1:2Br8BPsdHEstw5x0KKAyEbVQJPIspA0/xqbje1dx9OI=
 github.com/project-codeflare/appwrapper v0.13.0/go.mod h1:sH9j/rXX6WIlZzFXUOuqK5pagASPZNhuCtdFK+3BDkw=
-github.com/project-codeflare/codeflare-common v0.0.0-20240528061920-68eadc29b5b0 h1:3Vz7D9/TwzrBNujHQZGb4L6UKu3siAWwVP4Bj3ByUrU=
-github.com/project-codeflare/codeflare-common v0.0.0-20240528061920-68eadc29b5b0/go.mod h1:tlPi2e1HZQuf7AAFc7keWdVUNcxV+Gfh6Ss4KAQs1O0=
+github.com/project-codeflare/codeflare-common v0.0.0-20240617130731-0c3f3b3c0e5f h1:KCpu3tYn4wqpSW3ce8WcMU3rkNy+0cfFTlG/ttbM2F4=
+github.com/project-codeflare/codeflare-common v0.0.0-20240617130731-0c3f3b3c0e5f/go.mod h1:tlPi2e1HZQuf7AAFc7keWdVUNcxV+Gfh6Ss4KAQs1O0=
 github.com/prometheus/client_golang v1.18.0 h1:HzFfmkOzH5Q8L8G+kSJKUx5dtG87sewO+FoDDqP5Tbk=
 github.com/prometheus/client_golang v1.18.0/go.mod h1:T+GXkCk5wSJyOqMIzVgvvjFDlkOQntgjkJWKrN5txjA=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=


### PR DESCRIPTION
# Issue link
<!-- insert a link to the GitHub issue -->
<!-- If the issue is closed with this PR enter 'Closes #<issue_number>' -->
[RHOAIENG-6450](https://issues.redhat.com/browse/RHOAIENG-6450)[RHOAIENG-6450](https://issues.redhat.com/browse/RHOAIENG-6450)
# What changes have been made
<!-- describe a summary of the change, add any additional motivation and context as needed -->
Updated e2e cert generator image to use the new Ray image `quay.io/project-codeflare/ray:2.20.0-py39-cu118`
# Verification steps
<!-- Add thorough verification steps with sufficient level of detail for those without context to verify the change-->
<!-- AND Add thorough upgrade verification steps OR include a reason as to why it is not required -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->
Run the SDK E2E tests using this PR CFO side and this [PR](https://github.com/project-codeflare/codeflare-sdk/pull/530) SDK side 
## Checks
- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] Testing is not required for this change

<!-- You can find out information on the review process at this link https://github.com/project-codeflare/codeflare/blob/develop/CONTRIBUTING.md#getting-feedback-on-your-contribution -->