### PR TITLE
Mutate and Validate RayCluster on SecurityContext

### DIFF
--- a/pkg/controllers/raycluster_webhook.go
+++ b/pkg/controllers/raycluster_webhook.go
@@ -124,6 +124,16 @@ func (w *rayClusterWebhook) Default(ctx context.Context, obj runtime.Object) err
 		}
 	}
 
+	// Set the security context for the head container and worker containers
+	for i := range rayCluster.Spec.HeadGroupSpec.Template.Spec.Containers {
+		rayCluster.Spec.HeadGroupSpec.Template.Spec.Containers[i].SecurityContext = securityContext()
+	}
+	for i := range rayCluster.Spec.WorkerGroupSpecs {
+		for j := range rayCluster.Spec.WorkerGroupSpecs[i].Template.Spec.Containers {
+			rayCluster.Spec.WorkerGroupSpecs[i].Template.Spec.Containers[j].SecurityContext = securityContext()
+		}
+	}
+
 	return nil
 }
 

--- a/pkg/controllers/raycluster_webhook_test.go
+++ b/pkg/controllers/raycluster_webhook_test.go
@@ -227,6 +227,22 @@ func TestRayClusterWebhookDefault(t *testing.T) {
 		}
 	})
 
+	t.Run("Expected required SecurityContext for each head group container", func(t *testing.T) {
+		for _, container := range validRayCluster.Spec.HeadGroupSpec.Template.Spec.Containers {
+			test.Expect(container.SecurityContext).To(Equal(securityContext()),
+				"Expected the required SecurityContext to be present in each head group container")
+		}
+	})
+
+	t.Run("Expected required SecurityContext for each worker group container", func(t *testing.T) {
+		for _, workerGroup := range validRayCluster.Spec.WorkerGroupSpecs {
+			for _, container := range workerGroup.Template.Spec.Containers {
+				test.Expect(container.SecurityContext).To(Equal(securityContext()),
+					"Expected the required SecurityContext to be present in each worker group container")
+			}
+		}
+	})
+
 }
 
 func TestValidateCreate(t *testing.T) {


### PR DESCRIPTION
# Issue link
<!-- insert a link to the GitHub issue -->
<!-- If the issue is closed with this PR enter 'Closes #<issue_number>' -->
Jira: https://issues.redhat.com/browse/RHOAIENG-7638 

# What changes have been made
<!-- describe a summary of the change, add any additional motivation and context as needed -->
- The Mutating Webhook will now add the required `SecurityContext` in the RayCluster's head and worker containers.
- The Validating Webhook will now check for the required `SecurityContext` in the RayCluster's head and worker containers.

# Verification steps
<!-- Add thorough verification steps with sufficient level of detail for those without context to verify the change-->
<!-- AND Add thorough upgrade verification steps OR include a reason as to why it is not required -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->
1. Create Data science project in RHOAI
2. Create and start workbench
3. Find OpenShift namespace corresponding to the Data science project name, add labels to the `namespace` resource with value:
- pod-security.kubernetes.io/enforce: restricted
- pod-security.kubernetes.io/enforce-version: v1.24
4. Clone SDK demo notebooks in Workbench
5. Setup Kueue resources
6. Run i.e. 0_basic_ray.ipynb Notebook, try to create Ray cluster
7. RayCluster should start with or without the labels set in the `Namespace` resource.
8. You may also check that the `SecurityContext` is added to both head and worker containers when the mentioned labels have been set.
9. Attempt to create a RayCluster without the `SecurityContext`, and attempt to update the `SecurityContext` once the RayCluster is created. The ValidatingWebhook should reject these actions.

## Checks
- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] Testing is not required for this change

<!-- You can find out information on the review process at this link https://github.com/project-codeflare/codeflare/blob/develop/CONTRIBUTING.md#getting-feedback-on-your-contribution -->