### PR TITLE
make oauth image and cert generator image configurable via env vars

### DIFF
--- a/.github/workflows/project-codeflare-release.yml
+++ b/.github/workflows/project-codeflare-release.yml
@@ -98,7 +98,18 @@ jobs:
     steps:
     - name: Release CodeFlare operator
       run: |
-        gh workflow run tag-and-build.yml --repo ${{ github.event.inputs.codeflare-repository-organization }}/codeflare-operator --ref ${{ github.ref }} --field is-stable=${{ github.event.inputs.is-stable }} --field version=${{ github.event.inputs.operator-version }} --field replaces=${{ github.event.inputs.replaces }} --field codeflare-sdk-version=${{ github.event.inputs.codeflare-sdk-version }} --field appwrapper-version=${{ github.event.inputs.appwrapper-version }} --field kuberay-version=${{ github.event.inputs.kuberay-version }} --field kueue-version=${{ github.event.inputs.kueue-version }} --field quay-organization=${{ github.event.inputs.quay-organization }} --field community-operators-prod-fork-organization=${{ github.event.inputs.codeflare-repository-organization }} --field community-operators-prod-organization=${{ github.event.inputs.community-operators-prod-organization }}
+        gh workflow run tag-and-build.yml --repo ${{ github.event.inputs.codeflare-repository-organization }}/codeflare-operator \
+        --ref ${{ github.ref }} \
+        --field is-stable=${{ github.event.inputs.is-stable }} \
+        --field version=${{ github.event.inputs.operator-version }} \
+        --field replaces=${{ github.event.inputs.replaces }} \
+        --field codeflare-sdk-version=${{ github.event.inputs.codeflare-sdk-version }} \
+        --field appwrapper-version=${{ github.event.inputs.appwrapper-version }} \
+        --field kuberay-version=${{ github.event.inputs.kuberay-version }} \
+        --field kueue-version=${{ github.event.inputs.kueue-version }} \
+        --field quay-organization=${{ github.event.inputs.quay-organization }} \
+        --field community-operators-prod-fork-organization=${{ github.event.inputs.codeflare-repository-organization }} \
+        --field community-operators-prod-organization=${{ github.event.inputs.community-operators-prod-organization }}
       env:
         GITHUB_TOKEN: ${{ secrets.CODEFLARE_MACHINE_ACCOUNT_TOKEN }}
       shell: bash

--- a/config/e2e/config.yaml
+++ b/config/e2e/config.yaml
@@ -7,6 +7,5 @@ data:
     kuberay:
       rayDashboardOAuthEnabled: false
       ingressDomain: "kind"
-      certGeneratorImage: quay.io/rhoai/ray:2.23.0-py39-cu121
     appwrapper:
       enabled: true

--- a/config/e2e/patch_resources.yaml
+++ b/config/e2e/patch_resources.yaml
@@ -3,3 +3,8 @@
 - op: replace
   path: /spec/template/spec/containers/0/imagePullPolicy
   value: IfNotPresent
+- op: add
+  path: /spec/template/spec/containers/0/env/-
+  value:
+    name: CERT_GENERATOR_IMAGE
+    value: quay.io/rhoai/ray:2.23.0-py39-cu121

--- a/main.go
+++ b/main.go
@@ -147,7 +147,6 @@ func main() {
 			RayDashboardOAuthEnabled: ptr.To(true),
 			IngressDomain:            "",
 			MTLSEnabled:              ptr.To(true),
-			CertGeneratorImage:       "registry.redhat.io/ubi9@sha256:770cf07083e1c85ae69c25181a205b7cdef63c11b794c89b3b487d4670b4c328",
 		},
 		AppWrapper: &config.AppWrapperConfiguration{
 			Enabled: ptr.To(false),

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -50,8 +50,6 @@ type KubeRayConfiguration struct {
 	IngressDomain string `json:"ingressDomain"`
 
 	MTLSEnabled *bool `json:"mTLSEnabled,omitempty"`
-
-	CertGeneratorImage string `json:"certGeneratorImage"`
 }
 
 type ControllerManager struct {

--- a/pkg/controllers/raycluster_webhook.go
+++ b/pkg/controllers/raycluster_webhook.go
@@ -231,7 +231,7 @@ func validateHeadGroupServiceAccountName(rayCluster *rayv1.RayCluster) field.Err
 func oauthProxyContainer(rayCluster *rayv1.RayCluster) corev1.Container {
 	return corev1.Container{
 		Name:  oauthProxyContainerName,
-		Image: "registry.redhat.io/openshift4/ose-oauth-proxy@sha256:1ea6a01bf3e63cdcf125c6064cbd4a4a270deaf0f157b3eabb78f60556840366",
+		Image: OAuthProxyImage,
 		Ports: []corev1.ContainerPort{
 			{ContainerPort: 8443, Name: "oauth-proxy"},
 		},
@@ -349,7 +349,7 @@ func rayHeadInitContainer(rayCluster *rayv1.RayCluster, config *config.KubeRayCo
 
 	initContainerHead := corev1.Container{
 		Name:  "create-cert",
-		Image: config.CertGeneratorImage,
+		Image: CertGeneratorImage,
 		Command: []string{
 			"sh",
 			"-c",
@@ -363,7 +363,7 @@ func rayHeadInitContainer(rayCluster *rayv1.RayCluster, config *config.KubeRayCo
 func rayWorkerInitContainer(config *config.KubeRayConfiguration) corev1.Container {
 	initContainerWorker := corev1.Container{
 		Name:  "create-cert",
-		Image: config.CertGeneratorImage,
+		Image: CertGeneratorImage,
 		Command: []string{
 			"sh",
 			"-c",

--- a/pkg/controllers/raycluster_webhook_test.go
+++ b/pkg/controllers/raycluster_webhook_test.go
@@ -243,7 +243,7 @@ func TestValidateCreate(t *testing.T) {
 						Containers: []corev1.Container{
 							{
 								Name:  oauthProxyContainerName,
-								Image: "registry.redhat.io/openshift4/ose-oauth-proxy@sha256:1ea6a01bf3e63cdcf125c6064cbd4a4a270deaf0f157b3eabb78f60556840366",
+								Image: OAuthProxyImage,
 								Ports: []corev1.ContainerPort{
 									{ContainerPort: 8443, Name: "oauth-proxy"},
 								},
@@ -363,7 +363,7 @@ func TestValidateUpdate(t *testing.T) {
 						Containers: []corev1.Container{
 							{
 								Name:  oauthProxyContainerName,
-								Image: "registry.redhat.io/openshift4/ose-oauth-proxy@sha256:1ea6a01bf3e63cdcf125c6064cbd4a4a270deaf0f157b3eabb78f60556840366",
+								Image: OAuthProxyImage,
 								Ports: []corev1.ContainerPort{
 									{ContainerPort: 8443, Name: "oauth-proxy"},
 								},
@@ -414,7 +414,7 @@ func TestValidateUpdate(t *testing.T) {
 						InitContainers: []corev1.Container{
 							{
 								Name:  "create-cert",
-								Image: "",
+								Image: "registry.redhat.io/ubi9@sha256:770cf07083e1c85ae69c25181a205b7cdef63c11b794c89b3b487d4670b4c328",
 								Command: []string{
 									"sh",
 									"-c",
@@ -490,7 +490,7 @@ func TestValidateUpdate(t *testing.T) {
 							InitContainers: []corev1.Container{
 								{
 									Name:  "create-cert",
-									Image: "",
+									Image: "registry.redhat.io/ubi9@sha256:770cf07083e1c85ae69c25181a205b7cdef63c11b794c89b3b487d4670b4c328",
 									Command: []string{
 										"sh",
 										"-c",

--- a/pkg/controllers/support.go
+++ b/pkg/controllers/support.go
@@ -1,6 +1,8 @@
 package controllers
 
 import (
+	"os"
+
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 
 	corev1 "k8s.io/api/core/v1"
@@ -13,6 +15,18 @@ import (
 
 	routeapply "github.com/openshift/client-go/route/applyconfigurations/route/v1"
 )
+
+var (
+	CertGeneratorImage = getEnv("CERT_GENERATOR_IMAGE", "registry.redhat.io/ubi9@sha256:770cf07083e1c85ae69c25181a205b7cdef63c11b794c89b3b487d4670b4c328")
+	OAuthProxyImage    = getEnv("OAUTH_PROXY_IMAGE", "registry.redhat.io/openshift4/ose-oauth-proxy@sha256:1ea6a01bf3e63cdcf125c6064cbd4a4a270deaf0f157b3eabb78f60556840366")
+)
+
+func getEnv(key, fallback string) string {
+	if value, ok := os.LookupEnv(key); ok {
+		return value
+	}
+	return fallback
+}
 
 func serviceNameFromCluster(cluster *rayv1.RayCluster) string {
 	return cluster.Name + "-head-svc"


### PR DESCRIPTION
# Issue link
https://issues.redhat.com/browse/RHOAIENG-8552

# What changes have been made
I've made the cert generator image and oauthproxy image build time configurable

# Verification steps
run operator and verify that the images specified via make build are respected in the resulting RayCluster

## Checks
- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [x] Manual tests
   - [ ] Testing is not required for this change

# Note
There was also discussion about making these configurable at deployment time. I think the only difference would be whether we would need to re-release CFO to update the vs the RHODS/ODH operator. I lean towards leaving it on our end via build args but I'm open to suggestions
<!-- You can find out information on the review process at this link https://github.com/project-codeflare/codeflare/blob/develop/CONTRIBUTING.md#getting-feedback-on-your-contribution -->