### PR TITLE
automatically inject default queue if not provided

### DIFF
--- a/pkg/controllers/raycluster_webhook_test.go
+++ b/pkg/controllers/raycluster_webhook_test.go
@@ -26,6 +26,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/project-codeflare/codeflare-operator/pkg/config"
 )
@@ -35,6 +36,7 @@ var (
 	rayClusterName = "test-raycluster"
 
 	rcWebhook = &rayClusterWebhook{
+		Client: fake.NewFakeClient(),
 		Config: &config.KubeRayConfiguration{},
 	}
 )


### PR DESCRIPTION
# Issue link
https://issues.redhat.com/browse/RHOAIENG-6467

# What changes have been made
If no LocalQueue is specified by RayCluster and a default LocalQueue is specified, then the default LocalQueue will be added to the RayCluster spec

# Verification steps

1. Install Kueue, Ray, and this branch of the CFO
2. Create a default queue using the label {"kueue.x-k8s.io/default-queue": 'true'}
3. create a RayCluster with no LocalQueue specified
    1. see that the default queue is added to the RayCluster's labels
4. create a RayCluster with a LocalQueue specified
    1. see that the specified LocalQueue remains  

## Checks
- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] Testing is not required for this change

<!-- You can find out information on the review process at this link https://github.com/project-codeflare/codeflare/blob/develop/CONTRIBUTING.md#getting-feedback-on-your-contribution -->