### PR TITLE
Upload KinD pod logs even when CFO deployment fails

### DIFF
--- a/.github/workflows/e2e_tests.yaml
+++ b/.github/workflows/e2e_tests.yaml
@@ -115,7 +115,7 @@ jobs:
 
       - name: Upload logs
         uses: actions/upload-artifact@v4
-        if: always() && steps.deploy.outcome == 'success'
+        if: always() && steps.kind-install.outcome == 'success'
         with:
           name: logs
           retention-days: 10


### PR DESCRIPTION
# Issue link
<!-- insert a link to the GitHub issue -->
<!-- If the issue is closed with this PR enter 'Closes #<issue_number>' -->

# What changes have been made
<!-- describe a summary of the change, add any additional motivation and context as needed -->
If CFO deployment fails for some reason, then no logs are uploaded in PR check artifacts.
That makes PR check issue analysis much harder. Logs are always useful.

# Verification steps
<!-- Add thorough verification steps with sufficient level of detail for those without context to verify the change-->
<!-- AND Add thorough upgrade verification steps OR include a reason as to why it is not required -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->
N/A

## Checks
- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] Testing is not required for this change

<!-- You can find out information on the review process at this link https://github.com/project-codeflare/codeflare/blob/develop/CONTRIBUTING.md#getting-feedback-on-your-contribution -->