### PR TITLE
Downgrade StatusReasonConflict errors to debug messages

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/project-codeflare/codeflare-operator
 go 1.22.2
 
 require (
+	github.com/go-logr/logr v1.4.2
 	github.com/onsi/ginkgo/v2 v2.19.0
 	github.com/onsi/gomega v1.33.1
 	github.com/open-policy-agent/cert-controller v0.10.1
@@ -51,7 +52,6 @@ require (
 	github.com/evanphx/json-patch v5.6.0+incompatible // indirect
 	github.com/evanphx/json-patch/v5 v5.8.0 // indirect
 	github.com/fsnotify/fsnotify v1.7.0 // indirect
-	github.com/go-logr/logr v1.4.2 // indirect
 	github.com/go-logr/zapr v1.3.0 // indirect
 	github.com/go-openapi/jsonpointer v0.20.0 // indirect
 	github.com/go-openapi/jsonreference v0.20.2 // indirect

--- a/main.go
+++ b/main.go
@@ -116,7 +116,7 @@ func main() {
 	zapOptions.BindFlags(flag.CommandLine)
 	flag.Parse()
 
-	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&zapOptions)))
+	ctrl.SetLogger(controllers.FilteredLogger(zap.New(zap.UseFlagOptions(&zapOptions))))
 	klog.SetLogger(ctrl.Log)
 
 	setupLog.Info("Build info",

--- a/pkg/controllers/support.go
+++ b/pkg/controllers/support.go
@@ -3,11 +3,13 @@ package controllers
 import (
 	"os"
 
+	"github.com/go-logr/logr"
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	v1 "k8s.io/client-go/applyconfigurations/meta/v1"
@@ -171,4 +173,42 @@ func withEnvVarName(name string) compare[corev1.EnvVar] {
 	return func(e1, e2 corev1.EnvVar) bool {
 		return e1.Name == name
 	}
+}
+
+// logSink implements a log sink with an error log filter
+type logSink struct {
+	sink logr.LogSink
+}
+
+func (l logSink) Init(info logr.RuntimeInfo) {
+	l.sink.Init(info)
+}
+
+func (l logSink) Enabled(level int) bool {
+	return l.sink.Enabled(level)
+}
+func (l logSink) Info(level int, msg string, keysAndValues ...any) {
+	l.sink.Info(level, msg, keysAndValues...)
+}
+
+func (l logSink) Error(err error, msg string, keysAndValues ...any) {
+	// downgrade StatusReasonConflict errors to debug messages
+	if errors.IsConflict(err) {
+		l.sink.Info(1, msg, append(keysAndValues, "error", err.Error())...)
+	} else {
+		l.sink.Error(err, msg, keysAndValues...)
+	}
+}
+
+func (l logSink) WithValues(keysAndValues ...any) logr.LogSink {
+	return logSink{l.sink.WithValues(keysAndValues...)}
+}
+
+func (l logSink) WithName(name string) logr.LogSink {
+	return logSink{l.sink.WithName(name)}
+}
+
+// FilteredLogger returns a copy of the logger with an error log filter
+func FilteredLogger(logger logr.Logger) logr.Logger {
+	return logger.WithSink(logSink{logger.GetSink()})
 }


### PR DESCRIPTION
The `codeflare-operator` log is littered with update conflict errors such as:
```2024-07-24T13:06:33Z    ERROR   Reconciler error        {"controller": "AppWrapper", "controllerGroup": "workload.codeflare.dev", "controllerKind": "AppWrapper", "AppWrapper": {"name":"kevin1-team-hw","namespace":"kevin1-team"}, "namespace": "kevin1-team", "name": "kevin1-team-hw", "reconcileID": "b6e57167-a357-4c67-85d1-f455e2b57ab6", "error": "Operation cannot be fulfilled on appwrappers.workload.codeflare.dev \"kevin1-team-hw\": the object has been modified; please apply your changes to the latest version and try again"}```

These update conflicts result from trying to update stale Kubernetes object revisions in etcd when multiple reconciliers (or users) are concurrently working on cached copies of these objects. These conflicts are harmless. They are handled by retrying the reconciliation loop, refreshing the cached object, and updating or patching the more recent revision. This process is entirely handled by the controller runtime but it involves returning the conflict error to the controller runtime to trigger these retries. Unfortunately, the controller runtime as a result unconditionally logs these harmless conflicts as errors, which is confusing users.

This PR therefore wraps the controller runtime logger with a filter that downgrades these log messages from `ERROR` to `DEBUG` messages, more accurately matching the gravity of the event.