### PR TITLE
add hash to end of resource names to avoid name clash

### DIFF
--- a/main.go
+++ b/main.go
@@ -248,7 +248,7 @@ func setupRayClusterController(mgr ctrl.Manager, cfg *config.CodeFlareOperatorCo
 	<-certsReady
 	setupLog.Info("Certs ready")
 
-	err := controllers.SetupRayClusterWebhookWithManager(mgr, cfg.KubeRay)
+	err := controllers.SetupRayClusterWebhookWithManager(mgr, cfg.KubeRay, OperatorVersion)
 	if err != nil {
 		return err
 	}

--- a/pkg/controllers/support.go
+++ b/pkg/controllers/support.go
@@ -1,6 +1,8 @@
 package controllers
 
 import (
+	"crypto/sha256"
+	"fmt"
 	"os"
 
 	"github.com/go-logr/logr"
@@ -208,4 +210,12 @@ func ownerRefForRayCluster(cluster *rayv1.RayCluster) *v1.OwnerReferenceApplyCon
 		WithName(cluster.Name).
 		WithUID(cluster.UID).
 		WithController(true)
+}
+
+var (
+	hashLength = 8
+)
+
+func seededHash(seed string, s string) string {
+	return fmt.Sprintf("%x", sha256.Sum256([]byte(seed+s)))[:hashLength]
 }


### PR DESCRIPTION
# Issue link
https://issues.redhat.com/browse/RHOAIENG-10129

# What changes have been made
created a function which takes a string and appends the controller name to it then hashes it to use as a suffix for the resources created by this controller to avoid naming conflicts

# Verification steps
<!-- Add thorough verification steps with sufficient level of detail for those without context to verify the change-->
<!-- AND Add thorough upgrade verification steps OR include a reason as to why it is not required -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->

## Checks
- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] Testing is not required for this change

<!-- You can find out information on the review process at this link https://github.com/project-codeflare/codeflare/blob/develop/CONTRIBUTING.md#getting-feedback-on-your-contribution -->