### PR TITLE
Add sleep before creating Kueue resources

### DIFF
--- a/test/e2e/setup.sh
+++ b/test/e2e/setup.sh
@@ -68,6 +68,7 @@ do
 done
 echo ""
 
+sleep 5
 echo Creating Kueue ResourceFlavor and ClusterQueue
 cat <<EOF | kubectl apply -f -
 apiVersion: kueue.x-k8s.io/v1beta1


### PR DESCRIPTION
Fixes following errors. Service for webhook is not available immediately: error appears Error from server (InternalError): error when creating "STDIN": Internal error occurred: failed calling webhook "mresourceflavor.kb.io": failed to call webhook: Post "https://kueue-webhook-service.kueue-system.svc:443/mutate-kueue-x-k8s-io-v1beta1-resourceflavor?timeout=10s": dial tcp 10.96.115.38:443: connect: connection refused
