### PR TITLE
RBAC fix to enable slack cluster queue lending limit adjustment

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -171,6 +171,16 @@ rules:
 - apiGroups:
   - kueue.x-k8s.io
   resources:
+  - clusterqueues
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - kueue.x-k8s.io
+  resources:
   - resourceflavors
   verbs:
   - get

--- a/pkg/controllers/appwrapper_controller.go
+++ b/pkg/controllers/appwrapper_controller.go
@@ -42,5 +42,6 @@ package controllers
 // +kubebuilder:rbac:groups=kueue.x-k8s.io,resources=resourceflavors,verbs=get;list;watch
 // +kubebuilder:rbac:groups=kueue.x-k8s.io,resources=workloadpriorityclasses,verbs=get;list;watch
 
-// permission to watch nodes for Autopilot integration
+// permission to watch nodes and edit clusterqueues for Autopilot integration
 //+kubebuilder:rbac:groups="",resources=nodes,verbs=get;list;watch
+//+kubebuilder:rbac:groups=kueue.x-k8s.io,resources=clusterqueues,verbs=get;list;watch;update;patch


### PR DESCRIPTION
The codeflare operator needs permission to read and write clusterqueues to enable the AppWrapper controller to adjust the lending limit of a designated slack cluster queue to reflect cordoned nodes.
