### PR TITLE
AppWrapper e2e: Remove creationTimestamp from marshalled template

### DIFF
--- a/test/e2e/mnist_pytorch_appwrapper_test.go
+++ b/test/e2e/mnist_pytorch_appwrapper_test.go
@@ -145,6 +145,9 @@ func runMnistPyTorchAppWrapper(t *testing.T, accelerator string, numberOfGpus in
 		},
 	}
 
+	raw := Raw(test, job)
+	raw = RemoveCreationTimestamp(test, raw)
+
 	// Create an AppWrapper resource
 	aw := &mcadv1beta2.AppWrapper{
 		TypeMeta: metav1.TypeMeta{
@@ -159,7 +162,7 @@ func runMnistPyTorchAppWrapper(t *testing.T, accelerator string, numberOfGpus in
 		Spec: mcadv1beta2.AppWrapperSpec{
 			Components: []mcadv1beta2.AppWrapperComponent{
 				{
-					Template: Raw(test, job),
+					Template: raw,
 				},
 			},
 		},

--- a/test/e2e/mnist_rayjob_raycluster_test.go
+++ b/test/e2e/mnist_rayjob_raycluster_test.go
@@ -135,6 +135,9 @@ func runMnistRayJobRayClusterAppWrapper(t *testing.T, accelerator string, number
 
 	// Create RayCluster, wrap in AppWrapper and assign to localqueue
 	rayCluster := constructRayCluster(test, namespace, mnist, numberOfGpus)
+	raw := Raw(test, rayCluster)
+	raw = RemoveCreationTimestamp(test, raw)
+
 	aw := &mcadv1beta2.AppWrapper{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: mcadv1beta2.GroupVersion.String(),
@@ -148,7 +151,7 @@ func runMnistRayJobRayClusterAppWrapper(t *testing.T, accelerator string, number
 		Spec: mcadv1beta2.AppWrapperSpec{
 			Components: []mcadv1beta2.AppWrapperComponent{
 				{
-					Template: Raw(test, rayCluster),
+					Template: raw,
 				},
 			},
 		},

--- a/test/e2e/support.go
+++ b/test/e2e/support.go
@@ -18,9 +18,12 @@ package e2e
 
 import (
 	"embed"
+	"strings"
 
 	"github.com/onsi/gomega"
 	"github.com/project-codeflare/codeflare-common/support"
+
+	"k8s.io/apimachinery/pkg/runtime"
 )
 
 //go:embed *.py *.txt *.sh
@@ -31,4 +34,12 @@ func ReadFile(t support.Test, fileName string) []byte {
 	file, err := files.ReadFile(fileName)
 	t.Expect(err).NotTo(gomega.HaveOccurred())
 	return file
+}
+
+func RemoveCreationTimestamp(t support.Test, rawExtension runtime.RawExtension) runtime.RawExtension {
+	t.T().Helper()
+	patchedRaw := strings.ReplaceAll(string(rawExtension.Raw), `"metadata":{"creationTimestamp":null},`, "")
+	return runtime.RawExtension{
+		Raw: []byte(patchedRaw),
+	}
 }


### PR DESCRIPTION
# Issue link
<!-- insert a link to the GitHub issue -->
<!-- If the issue is closed with this PR enter 'Closes #<issue_number>' -->

# What changes have been made
<!-- describe a summary of the change, add any additional motivation and context as needed -->
Remove creationTimestamp from marshalled template for AppWrapper. This creationTimestamp is brought by marshaller (it is not omitted because it is defined as struct instead of pointer in k8s API). This field breaks Kueue reconciliation in AppWrapper for Kueue 0.8.3.

# Verification steps
<!-- Add thorough verification steps with sufficient level of detail for those without context to verify the change-->
<!-- AND Add thorough upgrade verification steps OR include a reason as to why it is not required -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->
The change was verified in https://github.com/project-codeflare/codeflare-operator/pull/628

## Checks
- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] Testing is not required for this change

<!-- You can find out information on the review process at this link https://github.com/project-codeflare/codeflare/blob/develop/CONTRIBUTING.md#getting-feedback-on-your-contribution -->