### PR TITLE
Add --cgroup-manager cgroupfs for e2e PR check

### DIFF
--- a/.github/workflows/e2e_tests.yaml
+++ b/.github/workflows/e2e_tests.yaml
@@ -75,6 +75,9 @@ jobs:
           kind load image-archive cfo.tar --name cluster --verbosity 1000
           make deploy -e IMG="${IMG}" -e ENV="e2e"
           kubectl wait --timeout=120s --for=condition=Available=true deployment -n openshift-operators codeflare-operator-manager
+        env:
+          # cgroup-manager configuration is required for NVidia image used in e2e PR check
+          IMAGE_BUILD_FLAGS: '--cgroup-manager cgroupfs'
 
       - name: Run e2e tests
         run: |

--- a/Makefile
+++ b/Makefile
@@ -77,6 +77,10 @@ endif
 
 # Image URL to use all building/pushing image targets
 IMG ?= ${IMAGE_TAG_BASE}:${VERSION}
+
+# IMAGE_BUILD_FLAGS are the flags passed to the podman operator image build command
+IMAGE_BUILD_FLAGS :=
+
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.24.2
 
@@ -184,7 +188,7 @@ run: manifests fmt vet ## Run a controller from your host.
 
 .PHONY: image-build
 image-build: test-unit ## Build container image with the manager.
-	podman build -t ${IMG} .
+	podman $(IMAGE_BUILD_FLAGS) build -t ${IMG} .
 
 .PHONY: image-push
 image-push: image-build ## Push container image with the manager.


### PR DESCRIPTION
# Issue link
<!-- insert a link to the GitHub issue -->
<!-- If the issue is closed with this PR enter 'Closes #<issue_number>' -->

# What changes have been made
<!-- describe a summary of the change, add any additional motivation and context as needed -->
Current changes in NVidia GitHub image and `codeflare-common` caused issues in building CFO image in NVidia GitHub image. Adding `--cgroup-manager cgroupfs` helps avoiding the error.
Solution taken from https://github.com/containers/podman/issues/6368 .

# Verification steps
<!-- Add thorough verification steps with sufficient level of detail for those without context to verify the change-->
<!-- AND Add thorough upgrade verification steps OR include a reason as to why it is not required -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->
Tested in PR check https://github.com/project-codeflare/codeflare-operator/pull/634

## Checks
- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] Testing is not required for this change

<!-- You can find out information on the review process at this link https://github.com/project-codeflare/codeflare/blob/develop/CONTRIBUTING.md#getting-feedback-on-your-contribution -->