### PR TITLE
update codeflare-common dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/openshift/api v0.0.0-20230823114715-5fdd7511b790
 	github.com/openshift/client-go v0.0.0-20221019143426-16aed247da5c
 	github.com/project-codeflare/appwrapper v0.27.0
-	github.com/project-codeflare/codeflare-common v0.0.0-20240930133152-11fd6e3be6b3
+	github.com/project-codeflare/codeflare-common v0.0.0-20241216183607-222395d38924
 	github.com/ray-project/kuberay/ray-operator v1.2.1
 	go.uber.org/zap v1.27.0
 	golang.org/x/exp v0.0.0-20240613232115-7f521ea00fb8

--- a/go.sum
+++ b/go.sum
@@ -226,8 +226,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/project-codeflare/appwrapper v0.27.0 h1:WiWw0Hi4rEXuFIEpm8nq1UqJHgVB6YtGcWzRrhRUTyE=
 github.com/project-codeflare/appwrapper v0.27.0/go.mod h1:7FpO90DLv0BAq4rwZtXKS9aRRfkR9RvXsj3pgYF0HtQ=
-github.com/project-codeflare/codeflare-common v0.0.0-20240930133152-11fd6e3be6b3 h1:Eupu9yxaGTddtoxb9SjrYJlokRHEYU5NNVRQmdXSNVs=
-github.com/project-codeflare/codeflare-common v0.0.0-20240930133152-11fd6e3be6b3/go.mod h1:v7XKwaDoCspsHQlWJNarO7gOpR+iumSS+c1bWs3kJOI=
+github.com/project-codeflare/codeflare-common v0.0.0-20241216183607-222395d38924 h1:jM+gYqn8eGmUoeQLGGYxlJgXZ1gbZgB2UtpKU9z0x9s=
+github.com/project-codeflare/codeflare-common v0.0.0-20241216183607-222395d38924/go.mod h1:DPSv5khRiRDFUD43SF8da+MrVQTWmxNhuKJmwSLOyO0=
 github.com/prometheus/client_golang v1.20.4 h1:Tgh3Yr67PaOv/uTqloMsCEdeuFTatm5zIq5+qNN23vI=
 github.com/prometheus/client_golang v1.20.4/go.mod h1:PIEt8X02hGcP8JWbeHyeZ53Y/jReSnHgO035n//V5WE=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=


### PR DESCRIPTION
Updating the codeflare-common dependency fixes this build problem:
```
(base) dgrove@Dave's IBM Mac codeflare-operator % SED=gsed make modules 
go get github.com/ray-project/kuberay/ray-operator@v1.1.0
go: downgraded github.com/project-codeflare/appwrapper v0.27.0 => v0.14.2
go: downgraded github.com/ray-project/kuberay/ray-operator v1.2.1 => v1.1.0
go: downgraded sigs.k8s.io/kueue v0.8.3 => v0.7.0-rc.1
go get sigs.k8s.io/kueue@v0.8.3
go: upgraded github.com/ray-project/kuberay/ray-operator v1.1.0 => v1.2.1
go: upgraded sigs.k8s.io/kueue v0.7.0-rc.1 => v0.8.3
go get github.com/project-codeflare/appwrapper@v0.27.0
go: upgraded github.com/project-codeflare/appwrapper v0.14.2 => v0.27.0
go mod tidy
go: finding module for package k8s.io/apimachinery/pkg/runtime/json
go: github.com/project-codeflare/codeflare-operator/test/e2e imports
	github.com/project-codeflare/codeflare-common/support imports
	k8s.io/apimachinery/pkg/runtime/json: module k8s.io/apimachinery@latest found (v0.32.0), but does not contain package k8s.io/apimachinery/pkg/runtime/json
make: *** [modules] Error 1
(base) dgrove@Dave's IBM Mac codeflare-operator % more go.mod   
module github.com/project-codeflare/codeflare-operator
```