### PR TITLE
Rename GPU GitHub runner to avoid version confusion

### DIFF
--- a/.github/workflows/e2e_tests.yaml
+++ b/.github/workflows/e2e_tests.yaml
@@ -27,7 +27,7 @@ concurrency:
 jobs:
   kubernetes-e2e:
 
-    runs-on: ubuntu-20.04-4core-gpu
+    runs-on: gpu-t4-4-core
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
# Issue link
<!-- insert a link to the GitHub issue -->
<!-- If the issue is closed with this PR enter 'Closes #<issue_number>' -->

# What changes have been made
<!-- describe a summary of the change, add any additional motivation and context as needed -->
Existing GPU runner references Ubuntu version in its name even though it is unrelated with GPU runner image.
Renaming the runner to a name corresponding to the runner image name.

# Verification steps
<!-- Add thorough verification steps with sufficient level of detail for those without context to verify the change-->
<!-- AND Add thorough upgrade verification steps OR include a reason as to why it is not required -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->

## Checks
- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] Testing is not required for this change

<!-- You can find out information on the review process at this link https://github.com/project-codeflare/codeflare/blob/develop/CONTRIBUTING.md#getting-feedback-on-your-contribution -->