### PR TITLE
Migrate GitHub runners to newest Ubuntu

### DIFF
--- a/.github/workflows/olm_tests.yaml
+++ b/.github/workflows/olm_tests.yaml
@@ -19,7 +19,7 @@ concurrency:
 
 jobs:
   kubernetes-olm-upgrade:
-    runs-on: ubuntu-20.04-4core
+    runs-on: ubuntu-latest-4core
     timeout-minutes: 60
     env:
       OLM_VERSION: v0.25.0


### PR DESCRIPTION
# Issue link
<!-- insert a link to the GitHub issue -->
<!-- If the issue is closed with this PR enter 'Closes #<issue_number>' -->

# What changes have been made
<!-- describe a summary of the change, add any additional motivation and context as needed -->
Ubuntu 20.04 image will become deprecated and removed in couple of months.
We need to migrate to newest version to keep PR checks running.

# Verification steps
<!-- Add thorough verification steps with sufficient level of detail for those without context to verify the change-->
<!-- AND Add thorough upgrade verification steps OR include a reason as to why it is not required -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->
OLM PR check is passing.

## Checks
- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] Testing is not required for this change

<!-- You can find out information on the review process at this link https://github.com/project-codeflare/codeflare/blob/develop/CONTRIBUTING.md#getting-feedback-on-your-contribution -->