### PR TITLE
Create oauth objects when RayCluster spec suspend is false

### DIFF
--- a/pkg/controllers/raycluster_controller_test.go
+++ b/pkg/controllers/raycluster_controller_test.go
@@ -21,6 +21,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/project-codeflare/codeflare-common/support"
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 
 	corev1 "k8s.io/api/core/v1"
@@ -65,6 +66,7 @@ var _ = Describe("RayCluster controller", func() {
 						},
 						RayStartParams: map[string]string{},
 					},
+					Suspend: support.Ptr(false),
 				},
 			}
 			_, err = rayClient.RayV1().RayClusters(namespace.Name).Create(ctx, raycluster, metav1.CreateOptions{})
@@ -209,6 +211,7 @@ var _ = Describe("RayCluster controller", func() {
 						},
 						RayStartParams: map[string]string{},
 					},
+					Suspend: support.Ptr(false),
 				},
 			}
 			_, err := rayClient.RayV1().RayClusters(namespaceName).Create(ctx, rayclusterWithPullSecret, metav1.CreateOptions{})


### PR DESCRIPTION
# Issue link
<!-- insert a link to the GitHub issue -->
<!-- If the issue is closed with this PR enter 'Closes #<issue_number>' -->

# What changes have been made
<!-- describe a summary of the change, add any additional motivation and context as needed -->
Use RayCluster `spec.suspend` field to detect that Ray cluster was admitted and oauth resources should be created.
Previous `status.state` field isn't usable any more as newer KubeRay version set state once Ray pods are up and running.

# Verification steps
<!-- Add thorough verification steps with sufficient level of detail for those without context to verify the change-->
<!-- AND Add thorough upgrade verification steps OR include a reason as to why it is not required -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->
Verified manually against OCP.

## Checks
- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] Testing is not required for this change

<!-- You can find out information on the review process at this link https://github.com/project-codeflare/codeflare/blob/develop/CONTRIBUTING.md#getting-feedback-on-your-contribution -->