### PR TITLE
Adjust test timeout on AppWrappers to decrease e2e tests duration

### DIFF
--- a/test/e2e/deployment_appwrapper_test.go
+++ b/test/e2e/deployment_appwrapper_test.go
@@ -153,7 +153,7 @@ func TestDeploymentAppWrapper(t *testing.T) {
 
 	// A deployment will not complete; so simply make sure it keeps running for reasonable interval
 	test.T().Logf("Ensuring the AppWrapper %s/%s continues to run", aw.Namespace, aw.Name)
-	test.Consistently(AppWrappers(test, namespace), TestTimeoutMedium).Should(
+	test.Consistently(AppWrappers(test, namespace), TestTimeoutShort).Should(
 		ContainElement(WithTransform(AppWrapperPhase, Equal(mcadv1beta2.AppWrapperRunning))))
 
 	test.T().Logf("Deleting AppWrapper %s/%s", aw.Namespace, aw.Name)


### PR DESCRIPTION
# Issue link
No Jira

## Context
Currently the e2e tests are taking around [45mins to complete](https://github.com/project-codeflare/codeflare-operator/actions/runs/13236544546/job/36942477253#step:10:33). There's a test running for 15mins, of which is required to run for only 2mins.

In the deployment_appwrapper_test.go file, there is [this test](https://github.com/project-codeflare/codeflare-operator/blob/f59ec01d866389bfb15dc19d2ef4e041a6a85672/test/e2e/deployment_appwrapper_test.go#L156) to make sure the AppWrapper continues to run for a set amount of time. The timeout set is [`TestTimeoutMedium` equal to 2m](https://github.com/project-codeflare/codeflare-common/blob/aeab5c7d68296cf33539aa200ce6f7b42befed25/support/support.go#L34).

However, in the e2e_tests.yaml workflow file, we've set the [environment variable for TestTimeoutMedium](https://github.com/project-codeflare/codeflare-operator/blob/f59ec01d866389bfb15dc19d2ef4e041a6a85672/.github/workflows/e2e_tests.yaml#L85), to be equal to 15mins, causing this test to always run for 15 minutes.

## Change
Changed in the deployment_appwrapper_test.go file the timeout from `TestTimeoutMedium` to `TestTimeoutShort`.