### PR TITLE
Upgrade AppWrapper from v1.0.0 to v1.0.4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ VERSION ?= v0.0.0-dev
 BUNDLE_VERSION ?= $(VERSION:v%=%)
 
 # APPWRAPPER_VERSION defines the default version of the AppWrapper controller
-APPWRAPPER_VERSION ?= v1.0.0
+APPWRAPPER_VERSION ?= v1.0.4
 APPWRAPPER_REPO ?= github.com/project-codeflare/appwrapper
 APPWRAPPER_CRD ?= ${APPWRAPPER_REPO}/config/crd?ref=${APPWRAPPER_VERSION}
 

--- a/config/crd/appwrapper/kustomization.yaml
+++ b/config/crd/appwrapper/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- github.com/project-codeflare/appwrapper/config/crd?ref=v1.0.0
+- github.com/project-codeflare/appwrapper/config/crd?ref=v1.0.4

--- a/config/crd/crd-appwrapper.yml
+++ b/config/crd/crd-appwrapper.yml
@@ -88,6 +88,20 @@ spec:
                                 type: string
                               description: NodeSelectors to be added to the PodSpecTemplate
                               type: object
+                            schedulingGates:
+                              description: SchedulingGates to be added to the PodSpecTemplate
+                              items:
+                                description: PodSchedulingGate is associated to a Pod to guard its scheduling.
+                                properties:
+                                  name:
+                                    description: |-
+                                      Name of the scheduling gate.
+                                      Each scheduling gate must have a unique name field.
+                                    type: string
+                                required:
+                                  - name
+                                type: object
+                              type: array
                             tolerations:
                               description: Tolerations to be added to the PodSpecTemplate
                               items:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -165,6 +165,18 @@ rules:
   - list
   - watch
 - apiGroups:
+  - jobset.x-k8s.io
+  resources:
+  - jobsets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - kubeflow.org
   resources:
   - pytorchjobs

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/opendatahub-io/opendatahub-operator/v2 v2.10.0
 	github.com/openshift/api v0.0.0-20240904015708-69df64132c91
 	github.com/openshift/client-go v0.0.0-20240904130219-3795e907a202
-	github.com/project-codeflare/appwrapper v1.0.0
+	github.com/project-codeflare/appwrapper v1.0.4
 	github.com/project-codeflare/codeflare-common v0.0.0-20250128135036-f501cd31fe8b
 	github.com/ray-project/kuberay/ray-operator v1.2.2
 	go.uber.org/zap v1.27.0

--- a/go.sum
+++ b/go.sum
@@ -223,8 +223,8 @@ github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/project-codeflare/appwrapper v1.0.0 h1:tKvBXxaIE5RwzUC8YZvxcnbuz4JUbiuLjo1IWO4Mciw=
-github.com/project-codeflare/appwrapper v1.0.0/go.mod h1:pVCWURfk9DOa/4ig7z91PJWRMlsDchhQVmu7mB32L48=
+github.com/project-codeflare/appwrapper v1.0.4 h1:364zQLX0tsi4LvBBYNKZL7PPbNWPbVU7vK6+/kVV/FQ=
+github.com/project-codeflare/appwrapper v1.0.4/go.mod h1:A1b6bMFNMX5Btv3ckgeuAHVVZzp1G30pSBe6BE/xJWE=
 github.com/project-codeflare/codeflare-common v0.0.0-20250128135036-f501cd31fe8b h1:MOmv/aLx/kcHd7PBErx8XNSTW180s8Slf/uVM0uV4rw=
 github.com/project-codeflare/codeflare-common v0.0.0-20250128135036-f501cd31fe8b/go.mod h1:DPSv5khRiRDFUD43SF8da+MrVQTWmxNhuKJmwSLOyO0=
 github.com/prometheus/client_golang v1.20.5 h1:cxppBPuYhUnsO6yo/aoRol4L7q7UFfdm+bR9r+8l63Y=

--- a/pkg/controllers/appwrapper_controller.go
+++ b/pkg/controllers/appwrapper_controller.go
@@ -32,6 +32,7 @@ package controllers
 //+kubebuilder:rbac:groups=kubeflow.org,resources=pytorchjobs,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=ray.io,resources=rayclusters,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=ray.io,resources=rayjobs,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=jobset.x-k8s.io,resources=jobsets,verbs=get;list;watch;create;update;patch;delete
 
 // permissions needed by Kueue's generic reconciller
 // +kubebuilder:rbac:groups=scheduling.k8s.io,resources=priorityclasses,verbs=list;get;watch


### PR DESCRIPTION
Features
  + Propagate SchedulingGates in RunWithPodSetsInfo
  + extend PodSets() to compute TopologyRequest
  + Support PreferNoSchedule labels for AutoPilot
  + Implement PodSet inference for JobSet

Bugs and Regressions
  + move appwrapper finalizer injection from defaulting webhook to controller
  + use ptr.Equal to validate managedBy is immutable
  + fix handling of labels/annotations in utils.GetPodTemplateSpec
