### PR TITLE
Upgrade cert generator image to use py3.11

### DIFF
--- a/config/e2e/patch_resources.yaml
+++ b/config/e2e/patch_resources.yaml
@@ -7,4 +7,4 @@
   path: /spec/template/spec/containers/0/env/-
   value:
     name: CERT_GENERATOR_IMAGE
-    value: quay.io/modh/ray:2.35.0-py39-cu121
+    value: quay.io/modh/ray:2.35.0-py311-cu121


### PR DESCRIPTION
# Issue link
<!-- insert a link to the GitHub issue -->
<!-- If the issue is closed with this PR enter 'Closes #<issue_number>' -->
Jira: https://issues.redhat.com/browse/RHOAIENG-20644 

# What changes have been made
<!-- describe a summary of the change, add any additional motivation and context as needed -->
Upgraded the cert generator image from py3.9 to py3.11 because the head pod py version differs from the cert image causing the head pod to not come up. This can be seen when running end to end tests locally. 

# Verification steps
<!-- Add thorough verification steps with sufficient level of detail for those without context to verify the change-->
<!-- AND Add thorough upgrade verification steps OR include a reason as to why it is not required -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->
run trough the end to end tests by following the updated readme instructions : https://github.com/projectcodeflare/codeflare-operator/pull/667

## Checks
- [x] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] Testing is not required for this change

<!-- You can find out information on the review process at this link https://github.com/project-codeflare/codeflare/blob/develop/CONTRIBUTING.md#getting-feedback-on-your-contribution -->