### PR TITLE
only use the applicationsNamespace in openshift

### DIFF
--- a/pkg/controllers/raycluster_controller.go
+++ b/pkg/controllers/raycluster_controller.go
@@ -269,18 +269,21 @@ func (r *RayClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	// Locate the KubeRay operator deployment:
 	// - First try to get the ODH / RHOAI application namespace from the DSCInitialization
 	// - Or fallback to the well-known defaults
+	// add check if running on openshift or vanilla kubernetes
 	var kubeRayNamespaces []string
-	dsci := &dsciv1.DSCInitialization{}
-	err := r.Client.Get(ctx, client.ObjectKey{Name: "default-dsci"}, dsci)
-	if errors.IsNotFound(err) {
-		kubeRayNamespaces = []string{"opendatahub", "redhat-ods-applications"}
-	} else if err != nil {
-		return ctrl.Result{}, err
-	} else {
-		kubeRayNamespaces = []string{dsci.Spec.ApplicationsNamespace}
+	kubeRayNamespaces = []string{"opendatahub", "redhat-ods-applications"}
+
+	if r.IsOpenShift {
+		dsci := &dsciv1.DSCInitialization{}
+		err := r.Client.Get(ctx, client.ObjectKey{Name: "default-dsci"}, dsci)
+		if err != nil {
+			return ctrl.Result{}, err
+		} else {
+			kubeRayNamespaces = []string{dsci.Spec.ApplicationsNamespace}
+		}
 	}
 
-	_, err = r.kubeClient.NetworkingV1().NetworkPolicies(cluster.Namespace).Apply(ctx, desiredHeadNetworkPolicy(cluster, r.Config, kubeRayNamespaces), metav1.ApplyOptions{FieldManager: controllerName, Force: true})
+	_, err := r.kubeClient.NetworkingV1().NetworkPolicies(cluster.Namespace).Apply(ctx, desiredHeadNetworkPolicy(cluster, r.Config, kubeRayNamespaces), metav1.ApplyOptions{FieldManager: controllerName, Force: true})
 	if err != nil {
 		logger.Error(err, "Failed to update NetworkPolicy")
 	}


### PR DESCRIPTION
the codeflare operator checks for kuberay namespaces to apply network policies so it uses opendatahub DSCInitialization CRD which isn't available on vanilla k8s clusters so added a condition to check for DSCInitialization only when running on openshift

This fixes the gatejobs running the codeflare-sdk repo as the e2e test jobs are failing because DSCInitialization isn't available on kind cluster that is being used for testing.

# Issue link
<!-- insert a link to the GitHub issue -->
<!-- If the issue is closed with this PR enter 'Closes #<issue_number>' -->

# What changes have been made
<!-- describe a summary of the change, add any additional motivation and context as needed -->

# Verification steps
<!-- Add thorough verification steps with sufficient level of detail for those without context to verify the change-->
<!-- AND Add thorough upgrade verification steps OR include a reason as to why it is not required -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->

## Checks
- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] Testing is not required for this change

<!-- You can find out information on the review process at this link https://github.com/project-codeflare/codeflare/blob/develop/CONTRIBUTING.md#getting-feedback-on-your-contribution -->